### PR TITLE
Fix `checkPropTypes` warning.

### DIFF
--- a/webpack/contents.js
+++ b/webpack/contents.js
@@ -33,7 +33,7 @@ export function getSection(playName, sectionName, callback, error) {
     .get(`/data/${playName}/${sectionName}.json`)
     .then(sectionResponse => {
       const props = sectionResponse.data;
-      props.startTime = props.startTime.value;
+      props.startTime = props.startTime.value || 0;
       props.endTime = props.endTime.value;
       props.duration = props.endTime - props.startTime;
       props.videoUrl = `${props.videoUrl.value}#t=${props.startTime},${


### PR DESCRIPTION
Closes #336.

The first section of each play has an empty `startTime` key in its generated JSON file, which causes a `checkPropTypes` warning to be emitted, as `startTime` is marked `isRequired` (as below).  One solution would be to change the `parse.js` script to write in a value of 0.  Another solution is this one.