### PR TITLE
Fix FontAwesome declaration for `.custom-checkbox`

### DIFF
--- a/src/_sass/components/_checkbox.scss
+++ b/src/_sass/components/_checkbox.scss
@@ -37,6 +37,8 @@
     }
 
     &::after {
+      @include text(xxs);
+
       align-items: center;
       display: flex;
       font-family: $font-icon;
@@ -44,8 +46,6 @@
       font-weight: normal;
       justify-content: center;
       top: 0.0625rem;
-
-      @include text(xxs);
     }
 
     .custom-checkbox__text {


### PR DESCRIPTION
Closes #333.

Checkmarks look as they should now.  (Odd error -- not sure how this crept in to the codebase, but whatever :))