### PR TITLE
Add a trailing slash to narrative links in generated JSON data files

### DIFF
--- a/webpack/__tests__/__snapshots__/parser.spec.js.snap
+++ b/webpack/__tests__/__snapshots__/parser.spec.js.snap
@@ -3025,7 +3025,7 @@ exports[`parser main downloads and parses phrases, metadata, and captions 8`] = 
       }
     }
   ],
-  \\"narrative\\": \\"/narratives/kokaji\\",
+  \\"narrative\\": \\"/narratives/kokaji/\\",
   \\"tracks\\": [
     {
       \\"label\\": \\"Translation\\",

--- a/webpack/scripts/parser.js
+++ b/webpack/scripts/parser.js
@@ -301,7 +301,7 @@ export const main = (configPath, quiet) => {
           map[play.playName] = play;
           map[play.playName].sections = [];
           map[play.playName].captions = [];
-          map[play.playName].narrative = `/narratives/${play.playName}`;
+          map[play.playName].narrative = `/narratives/${play.playName}/`;
         }
         map[play.playName].captions.push(...section.captions);
         delete section.captions;


### PR DESCRIPTION
Closes #338.

Without this the XHRs are causing an unnecessary 301 redirect.  (Note: for this to make a difference the data needs to be deleted / re-generated.)