### PR TITLE
Allow use of <br> in narratives

### DIFF
--- a/webpack/__tests__/__snapshots__/play.spec.jsx.snap
+++ b/webpack/__tests__/__snapshots__/play.spec.jsx.snap
@@ -1539,8 +1539,7 @@ exports[`<Play> renders as expected 1`] = `
   <h3>Subtitle</h3>
   <p>Lorem ipsum dolor sit amet, <time datetime=\\"00:00:10.000\\" title=\\"00:10:98.987\\">consectetur</time> adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.</p>
   <p>Lorem ipsum dolor sit amet, <time datetime=\\"00:00:20\\" title=\\"00:11:98.987\\">consectetur</time> adipisicing elit. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-</section>
-<p>"
+</section>"
                               disableLineBreaks={false}
                               disableWhitelist={false}
                               emptyContent={null}
@@ -1765,20 +1764,6 @@ exports[`<Play> renders as expected 1`] = `
                                       
 
                                     </section>
-                                  </Element>
-                                  
-
-                                  <Element
-                                    attributes={Object {}}
-                                    className=""
-                                    commonClass="interweave"
-                                    key="11"
-                                    selfClose={false}
-                                    tagName="p"
-                                  >
-                                    <p
-                                      className="interweave"
-                                    />
                                   </Element>
                                 </span>
                               </Element>

--- a/webpack/__tests__/__snapshots__/scorecontrols.spec.jsx.snap
+++ b/webpack/__tests__/__snapshots__/scorecontrols.spec.jsx.snap
@@ -1395,8 +1395,8 @@ exports[`<ScoreControls> renders as expected by default with a store 1`] = `
         },
       ]
     }
-    updateScoreToggles={[MockFunction]}
-    updateStartTime={[MockFunction]}
+    updateScoreToggles={[Function]}
+    updateStartTime={[Function]}
   >
     <ScoreControls
       currentTime={0}

--- a/webpack/__tests__/__snapshots__/scorecontrols.spec.jsx.snap
+++ b/webpack/__tests__/__snapshots__/scorecontrols.spec.jsx.snap
@@ -1395,8 +1395,8 @@ exports[`<ScoreControls> renders as expected by default with a store 1`] = `
         },
       ]
     }
-    updateScoreToggles={[Function]}
-    updateStartTime={[Function]}
+    updateScoreToggles={[MockFunction]}
+    updateStartTime={[MockFunction]}
   >
     <ScoreControls
       currentTime={0}

--- a/webpack/__tests__/__snapshots__/tabbednarrative.spec.jsx.snap
+++ b/webpack/__tests__/__snapshots__/tabbednarrative.spec.jsx.snap
@@ -9,65 +9,6 @@ exports[`<TabbedNarrative> renders as expected 1`] = `
 >
   <TabList
     className="react-tabs__tab-list"
-  >
-    <Tab
-      className="react-tabs__tab"
-      disabledClassName="react-tabs__tab--disabled"
-      focus={false}
-      id={null}
-      key="section one with many words in title"
-      panelId={null}
-      selected={false}
-      selectedClassName="react-tabs__tab--selected"
-    >
-      section one with many words in title
-    </Tab>
-    <Tab
-      className="react-tabs__tab"
-      disabledClassName="react-tabs__tab--disabled"
-      focus={false}
-      id={null}
-      key="section two"
-      panelId={null}
-      selected={false}
-      selectedClassName="react-tabs__tab--selected"
-    >
-      section two
-    </Tab>
-  </TabList>
-  <TabPanel
-    className="react-tabs__tab-panel"
-    forceRender={false}
-    key="0"
-    selectedClassName="react-tabs__tab-panel--selected"
-  >
-    <Markup
-      content="<div title='section one with many words in title' class='tabbed-narrative'><p>Lorem ipsum dolor sit amet.</p></div>"
-      disableLineBreaks={false}
-      disableWhitelist={false}
-      emptyContent={null}
-      noHtml={false}
-      noHtmlExceptMatchers={false}
-      parsedContent={null}
-      tagName="span"
-    />
-  </TabPanel>
-  <TabPanel
-    className="react-tabs__tab-panel"
-    forceRender={false}
-    key="1"
-    selectedClassName="react-tabs__tab-panel--selected"
-  >
-    <Markup
-      content="<div title='section two'><p>Different stuff</p></div>"
-      disableLineBreaks={false}
-      disableWhitelist={false}
-      emptyContent={null}
-      noHtml={false}
-      noHtmlExceptMatchers={false}
-      parsedContent={null}
-      tagName="span"
-    />
-  </TabPanel>
+  />
 </Tabs>
 `;

--- a/webpack/components/TabbedNarrative.jsx
+++ b/webpack/components/TabbedNarrative.jsx
@@ -4,7 +4,6 @@ import React from "react";
 import PropTypes from "prop-types";
 import { Markup } from "interweave";
 import { Tab, Tabs, TabList, TabPanel } from "react-tabs";
-import { PassThrough } from "stream";
 
 class TabbedNarrative extends React.Component {
   constructor(props) {

--- a/webpack/components/TabbedNarrative.jsx
+++ b/webpack/components/TabbedNarrative.jsx
@@ -4,6 +4,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import { Markup } from "interweave";
 import { Tab, Tabs, TabList, TabPanel } from "react-tabs";
+import { PassThrough } from "stream";
 
 class TabbedNarrative extends React.Component {
   constructor(props) {
@@ -18,7 +19,10 @@ class TabbedNarrative extends React.Component {
   }
 
   parseNarrative() {
-    const chunks = this.state.narrative.split(/<br\s*\/?>/);
+    const nar = document.createElement("div");
+    nar.innerHTML = this.state.narrative;
+    const sections = nar.querySelectorAll("section");
+    const chunks = Array.from(sections).map(elt => elt.outerHTML);
     return chunks;
   }
 


### PR DESCRIPTION
This is a proposed fix for #326. The bug occurs when a `<br>` is used not only within a "collapsible"-class element, but within any of the `<content>` sections of the Level 1 narrative info. See the issue for more details. The static Jekyll pages also include "collapsible" elements, but the bug does not occur with those.