### PR TITLE
Modifications to support hash fragment links from same page

### DIFF
--- a/src/assets/tabs.js
+++ b/src/assets/tabs.js
@@ -3,90 +3,100 @@ var tabClass = "react-tabs__tab";
 function attachTabs() {
   /* This function is run after the page loads. It iterates
    * through the "dehydrated" tab containers on the page and
-   * "hydrates" their tab link bar and contents sections, selecting
-   * the first tab by default.
-   * A click handler is registered for each tab link, which calls
-   * activateTab(). activateTab() is also run at the end of this
-   * function if there is a hash fragment in the URL, directing that
-   * the specified tab should be activated and brought into focus.
+   * "hydrates" their tab link bar and contents sections. It also
+   * notices if a section ID matches the value in the URL hash
+   * fragment (if present), and calls activateTab() to enable
+   * either this tab or else the first tab in the container.
    */
 
+  var tabID = undefined;
+  if (window.location.hash) tabID = window.location.hash.slice(1);
+
+  // Iterate through all of the tab containers on the page
   var containers = document.querySelectorAll("div.tabs-container");
   containers.forEach(function(container) {
     var ul = document.createElement("ul");
     ul.classList.add(tabClass + "-list");
     var sections = container.querySelectorAll("section");
+    var tabIDtoActivate = undefined;
+    var jumpToTab = false;
     sections.forEach(function(section, idx) {
       var li = document.createElement("li");
       li.classList.add(tabClass);
       li.setAttribute("role", "tab");
       li.setAttribute("aria-controls", section.id);
-      // Activate the first tab by default
-      if (idx == 0) {
-        section.style.display = "block";
-        li.classList.add(tabClass + "--selected");
-        li.setAttribute("aria-selected", "true");
-      } else {
-        section.style.display = "none";
-        li.setAttribute("aria-selected", "false");
+
+      /* Nominate the tab identified in the URL hash fragment,
+       * or else the first tab in the block.
+       */
+      if (tabID && tabID == section.id) {
+        tabIDtoActivate = section.id;
+        jumpToTab = true;
+      } else if (idx == 0) {
+        tabIDtoActivate = section.id;
       }
       li.appendChild(document.createTextNode(section.title));
       li.addEventListener("click", function() {
-        activateTab(null, section.id);
+        activateTab(undefined, section.id, false);
       });
       ul.appendChild(li);
     });
     container.querySelector("div.wrapper").children[0].appendChild(ul);
+    activateTab(undefined, tabIDtoActivate, jumpToTab);
   });
-
-  if (window.location.hash) activateTab();
 }
 
-function activateTab(hashEvent, tabID) {
-  /* This function is called when a tab link is clicked in any of
+function activateTab(hashEvent, tabID, jumpToTab = false) {
+  /* This function is called when the page is first loaded (after
+   * attachTabs() has run), when a tab link is clicked in any of
    * the tab containers on the page, and also when the window's hash
    * fragment changes. It activates the tab IDed in the parameter or the URL
-   * and, if invoked due to a hash fragment change, scrolls the window to the
-   * top of the proper tab container. The manual scrolling is ncessary because
-   * the placement of the tab IDs (in the section body, rather than the link)
-   * otherwise will cause the browser to scroll too far.
+   * and, if invoked due to a hash fragment change or a page load with a hash
+   * fragment in the URL, scrolls the window to the top of the appropriate tab
+   * container.
    */
 
-  if (tabID === "undefined" && window.location.hash)
+  if (tabID === undefined && window.location.hash) {
     tabID = window.location.hash.slice(1);
+    jumpToTab = true;
+  }
 
+  /* Neet to iterate through all tab containers and their content sections
+   * because getElementById() won't find a tab content section if that
+   * section/tab has been disabled/deselected.
+   */
   var containers = document.querySelectorAll("div.tabs-container");
   containers.forEach(function(container) {
     var matchedSectionIndex = -1;
     var sections = container.querySelectorAll("section");
-    sections.forEach(function(section, idx) {
-      if (section.id == tabID) matchedSectionIndex = idx;
-    });
-
-    // Move on to the next container if this one doesn't contain the tab
-    if (matchedSectionIndex < 0) return;
-
-    var ul = container.querySelector("ul");
-    var lis = ul.querySelectorAll("li." + tabClass);
-    // Deactivate/activate the tabs and content panes
-    lis.forEach(function(li_, liIndex) {
-      if (liIndex != matchedSectionIndex) {
-        li_.classList.remove(tabClass + "--selected");
-        li_.setAttribute("aria-selected", "false");
-      } else {
-        li_.classList.add(tabClass + "--selected");
-        li_.setAttribute("aria-selected", "true");
+    sections.forEach(function(_section, idx) {
+      if (_section.id == tabID) {
+        matchedSectionIndex = idx;
       }
     });
-    sections.forEach(function(section_, sectionIndex) {
-      if (sectionIndex != matchedSectionIndex) section_.style.display = "none";
-      else section_.style.display = "block";
-    });
-
-    if (hashEvent) container.scrollIntoView();
+    if (matchedSectionIndex >= 0) {
+      sections.forEach(function(_section, idx) {
+        _section.style.display = "none";
+        if (_section.id == tabID) {
+          _section.style.display = "block";
+        }
+      });
+      var lis = container.querySelectorAll("li." + tabClass);
+      // Deactivate/activate the tab links
+      lis.forEach(function(li_, liIndex) {
+        if (liIndex != matchedSectionIndex) {
+          li_.classList.remove(tabClass + "--selected");
+          li_.setAttribute("aria-selected", "false");
+        } else {
+          li_.classList.add(tabClass + "--selected");
+          li_.setAttribute("aria-selected", "true");
+        }
+      });
+      if (jumpToTab) container.scrollIntoView();
+    }
   });
 }
 
-window.addEventListener("hashchange", activateTab, false);
-
 attachTabs();
+
+window.addEventListener("hashchange", activateTab, false);


### PR DESCRIPTION
This PR addresses a bug from the previous version wherein links via a hash fragment to a tab on the *same* page would fail to load because the tab section ID specified in the URL would most likely be disabled and thus not findable via `getElementById()`. Such links from *other* pages would work fine, though, because they would involve a full rendering of the tab sets.
The root cause of these challenges is that the IDs of the tabs are stored in the content sections rather than the heading links; by definition, most of the former are disabled after the page has loaded. This fix should provide the desired functionality while retaining backwards compatibility and isomorphism with the existing "dehydrated" tab group template.
