### PR TITLE
Persist filters in localstorage

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "enzyme-adapter-react-16": "^1.0.2",
     "global": "^4.3.2",
     "interweave": "^8.0.2",
+    "lodash.throttle": "^4.1.1",
     "mkdirp": "^0.5.1",
     "papaparse": "^4.3.6",
     "prop-types": "^15.6.0",

--- a/webpack/__tests__/__snapshots__/score.spec.jsx.snap
+++ b/webpack/__tests__/__snapshots__/score.spec.jsx.snap
@@ -1084,6 +1084,608 @@ exports[`<UnwrappedScore> renders as expected 1`] = `
 </div>
 `;
 
+exports[`<UnwrappedScore> renders as expected 2`] = `
+<div
+  className="score"
+>
+  <div
+    className="measure measure--previous"
+  >
+    <MeasureLabelContainer
+      isBeatOn={true}
+      isDanceOn={true}
+      isNextSentenceOn={true}
+      isNohkanOn={true}
+      isPercussionOn={true}
+      isPrevSentenceOn={true}
+      isTextOn={true}
+      next={false}
+      previous={true}
+    />
+    <div
+      className="measure__grid-container"
+    >
+      <div
+        className="measure__grid-container"
+      >
+        <div
+          className="measure__channel measure__channel--5"
+        >
+          <p
+            className="measure__channel-empty"
+          >
+            No score in this sentence
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    className="measure measure--current"
+  >
+    <MeasureLabelContainer
+      current={true}
+      isBeatOn={true}
+      isDanceOn={true}
+      isNextSentenceOn={true}
+      isNohkanOn={true}
+      isPercussionOn={true}
+      isPrevSentenceOn={true}
+      isTextOn={true}
+      next={false}
+      previous={false}
+    />
+    <div
+      className="measure__grid-container"
+    >
+      <div
+        className="measure__grid-container"
+      >
+        <div
+          className="measure__channel"
+          key="measure-beats"
+        >
+          <CellBeat
+            beatText=""
+            key="beatNum0"
+            length={1}
+          />
+          <CellBeat
+            beatText="1"
+            key="beatNum1"
+            length={1}
+          />
+          <CellBeat
+            beatText="2"
+            key="beatNum2"
+            length={1}
+          />
+          <CellBeat
+            beatText=""
+            key="beatNum3"
+            length={1}
+          />
+          <CellBeat
+            beatText="3"
+            key="beatNum4"
+            length={1}
+          />
+          <CellBeat
+            beatText="4"
+            key="beatNum5"
+            length={1}
+          />
+          <CellBeat
+            beatText=""
+            key="beatNum6"
+            length={1}
+          />
+          <CellBeat
+            beatText="5"
+            key="beatNum7"
+            length={1}
+          />
+          <CellBeat
+            beatText="6"
+            key="beatNum8"
+            length={1}
+          />
+          <CellBeat
+            beatText=""
+            key="beatNum9"
+            length={1}
+          />
+          <CellBeat
+            beatText="7"
+            key="beatNum10"
+            length={1}
+          />
+          <CellBeat
+            beatText=""
+            key="beatNum11"
+            length={1}
+          />
+          <CellBeat
+            beatText="8"
+            key="beatNum12"
+            length={1}
+          />
+        </div>
+        <div
+          className="measure__channel"
+          key="measure-text"
+        >
+          <ScoreTextLine
+            length={13}
+            rangeGrid={
+              Array [
+                Object {
+                  "length": 13,
+                  "start": 0,
+                  "style": "normal",
+                  "text": "l",
+                  "voices": Array [],
+                },
+              ]
+            }
+            textGrid={
+              Array [
+                Object {
+                  "length": 1,
+                  "start": 0,
+                  "style": "normal",
+                  "text": "ma",
+                  "voices": Array [
+                    "jiutai",
+                  ],
+                },
+                Object {
+                  "length": 1,
+                  "start": 1,
+                  "style": "normal",
+                  "text": "ta",
+                  "voices": Array [],
+                },
+                Object {
+                  "length": 1,
+                  "start": 2,
+                  "style": "normal",
+                  "text": "wa",
+                  "voices": Array [
+                    "jiutai",
+                  ],
+                },
+                Object {
+                  "length": 1,
+                  "start": 3,
+                  "style": "normal",
+                  "text": "ga",
+                  "voices": Array [
+                    "shite",
+                  ],
+                },
+                Object {
+                  "length": 1,
+                  "start": 4,
+                  "style": "normal",
+                  "text": "cho",
+                  "voices": Array [],
+                },
+                Object {
+                  "length": 1,
+                  "start": 5,
+                  "style": "normal",
+                  "text": "o",
+                  "voices": Array [],
+                },
+                Object {
+                  "length": 1,
+                  "start": 6,
+                  "style": "normal",
+                  "text": "no",
+                  "voices": Array [
+                    "jiutai",
+                  ],
+                },
+                Object {
+                  "length": 1,
+                  "start": 7,
+                  "style": "normal",
+                  "text": "so",
+                  "voices": Array [],
+                },
+                Object {
+                  "length": 1,
+                  "start": 8,
+                  "style": "normal",
+                  "text": "no",
+                  "voices": Array [],
+                },
+                Object {
+                  "length": 1,
+                  "start": 9,
+                  "style": "normal",
+                  "text": "ha",
+                  "voices": Array [],
+                },
+                Object {
+                  "length": 1,
+                  "start": 10,
+                  "style": "normal",
+                  "text": "ji",
+                  "voices": Array [],
+                },
+                Object {
+                  "length": 1,
+                  "start": 11,
+                  "style": "normal",
+                  "text": "me",
+                  "voices": Array [],
+                },
+                Object {
+                  "length": 1,
+                  "start": 12,
+                  "style": "normal",
+                  "text": "(e)",
+                  "voices": Array [
+                    "shite",
+                  ],
+                },
+              ]
+            }
+          />
+        </div>
+        <div
+          className="measure__channel"
+          key="measure-percussion"
+        >
+          <CellPercussion
+            length={13}
+            text="mitsuji"
+          />
+        </div>
+        <div
+          className="measure__channel"
+          key="measure-nohkan"
+        >
+          <NohkanLine
+            grid={
+              Array [
+                Object {
+                  "length": 2,
+                  "start": 1,
+                  "style": "normal",
+                  "text": "Naka no takane",
+                  "voices": Array [],
+                },
+                Object {
+                  "length": 1,
+                  "start": 4,
+                  "style": "normal",
+                  "text": "Naka no takane",
+                  "voices": Array [],
+                },
+                Object {
+                  "length": 2,
+                  "start": 5,
+                  "style": "normal",
+                  "text": "Naka no takane",
+                  "voices": Array [],
+                },
+                Object {
+                  "length": 2,
+                  "start": 10,
+                  "style": "normal",
+                  "text": "Naka no takane",
+                  "voices": Array [],
+                },
+              ]
+            }
+            length={13}
+          />
+        </div>
+        <div
+          className="measure__channel"
+          key="measure-dance"
+        >
+          <DanceLine
+            grid={
+              Array [
+                Object {
+                  "length": 4,
+                  "start": 1,
+                  "style": "normal",
+                  "text": "9. Kneeling facing front.",
+                  "voices": Array [],
+                },
+              ]
+            }
+            length={13}
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    className="measure measure--next"
+  >
+    <MeasureLabelContainer
+      isBeatOn={true}
+      isDanceOn={true}
+      isNextSentenceOn={true}
+      isNohkanOn={true}
+      isPercussionOn={true}
+      isPrevSentenceOn={true}
+      isTextOn={true}
+      next={true}
+      previous={false}
+    />
+    <div
+      className="measure__grid-container"
+    >
+      <div
+        className="measure__grid-container"
+      >
+        <div
+          className="measure__channel"
+          key="measure-beats"
+        >
+          <CellBeat
+            beatText=""
+            key="beatNum0"
+            length={1}
+          />
+          <CellBeat
+            beatText="1"
+            key="beatNum1"
+            length={1}
+          />
+          <CellBeat
+            beatText="2"
+            key="beatNum2"
+            length={1}
+          />
+          <CellBeat
+            beatText=""
+            key="beatNum3"
+            length={1}
+          />
+          <CellBeat
+            beatText="3"
+            key="beatNum4"
+            length={1}
+          />
+          <CellBeat
+            beatText="4"
+            key="beatNum5"
+            length={1}
+          />
+          <CellBeat
+            beatText=""
+            key="beatNum6"
+            length={1}
+          />
+          <CellBeat
+            beatText="5"
+            key="beatNum7"
+            length={1}
+          />
+          <CellBeat
+            beatText="6"
+            key="beatNum8"
+            length={1}
+          />
+          <CellBeat
+            beatText=""
+            key="beatNum9"
+            length={1}
+          />
+          <CellBeat
+            beatText="7"
+            key="beatNum10"
+            length={1}
+          />
+          <CellBeat
+            beatText=""
+            key="beatNum11"
+            length={1}
+          />
+          <CellBeat
+            beatText="8"
+            key="beatNum12"
+            length={1}
+          />
+        </div>
+        <div
+          className="measure__channel"
+          key="measure-text"
+        >
+          <ScoreTextLine
+            length={13}
+            rangeGrid={
+              Array [
+                Object {
+                  "length": 6,
+                  "start": 3,
+                  "style": "normal",
+                  "text": "m",
+                  "voices": Array [],
+                },
+                Object {
+                  "length": 3,
+                  "start": 9,
+                  "style": "normal",
+                  "text": "l",
+                  "voices": Array [],
+                },
+              ]
+            }
+            textGrid={
+              Array [
+                Object {
+                  "length": 1,
+                  "start": 3,
+                  "style": "normal",
+                  "text": "ni",
+                  "voices": Array [],
+                },
+                Object {
+                  "length": 1,
+                  "start": 4,
+                  "style": "normal",
+                  "text": "n",
+                  "voices": Array [],
+                },
+                Object {
+                  "length": 1,
+                  "start": 5,
+                  "style": "normal",
+                  "text": "no",
+                  "voices": Array [],
+                },
+                Object {
+                  "length": 1,
+                  "start": 6,
+                  "style": "normal",
+                  "text": "o",
+                  "voices": Array [],
+                },
+                Object {
+                  "length": 1,
+                  "start": 7,
+                  "style": "normal",
+                  "text": "ji",
+                  "voices": Array [],
+                },
+                Object {
+                  "length": 1,
+                  "start": 8,
+                  "style": "normal",
+                  "text": "u",
+                  "voices": Array [],
+                },
+                Object {
+                  "length": 1,
+                  "start": 9,
+                  "style": "normal",
+                  "text": "ni",
+                  "voices": Array [],
+                },
+                Object {
+                  "length": 1,
+                  "start": 10,
+                  "style": "normal",
+                  "text": "da",
+                  "voices": Array [],
+                },
+                Object {
+                  "length": 1,
+                  "start": 11,
+                  "style": "normal",
+                  "text": "i",
+                  "voices": Array [],
+                },
+              ]
+            }
+          />
+        </div>
+        <div
+          className="measure__channel"
+          key="measure-percussion"
+        >
+          <CellPercussion
+            length={13}
+            text=""
+          />
+        </div>
+        <div
+          className="measure__channel"
+          key="measure-nohkan"
+        >
+          <NohkanLine
+            grid={
+              Array [
+                Object {
+                  "length": 2,
+                  "start": 3,
+                  "style": "normal",
+                  "text": "Naka no takane",
+                  "voices": Array [],
+                },
+                Object {
+                  "length": 1,
+                  "start": 8,
+                  "style": "normal",
+                  "text": "Naka no takane",
+                  "voices": Array [],
+                },
+              ]
+            }
+            length={13}
+          />
+        </div>
+        <div
+          className="measure__channel"
+          key="measure-dance"
+        >
+          <DanceLine
+            grid={
+              Array [
+                Object {
+                  "length": 3,
+                  "start": 0,
+                  "style": "normal",
+                  "text": "and gazes in the distance.",
+                  "voices": Array [],
+                },
+                Object {
+                  "length": 2,
+                  "start": 6,
+                  "style": "normal",
+                  "text": "9. Sits back on his knee.",
+                  "voices": Array [],
+                },
+              ]
+            }
+            length={13}
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`<UnwrappedScore> renders as expected with all filters off 1`] = `
+<div
+  className="score"
+>
+  <div
+    className="measure measure--current"
+  >
+    <MeasureLabelContainer
+      current={true}
+      isBeatOn={false}
+      isDanceOn={false}
+      isNextSentenceOn={false}
+      isNohkanOn={false}
+      isPercussionOn={false}
+      isPrevSentenceOn={false}
+      isTextOn={false}
+      next={false}
+      previous={false}
+    />
+    <div
+      className="measure__grid-container"
+    >
+      <div
+        className="measure__grid-container"
+      />
+    </div>
+  </div>
+</div>
+`;
+
 exports[`<UnwrappedScore> renders as expected with unmetered phrases 1`] = `
 <div
   className="score"

--- a/webpack/__tests__/__snapshots__/scorecontrols.spec.jsx.snap
+++ b/webpack/__tests__/__snapshots__/scorecontrols.spec.jsx.snap
@@ -1406,7 +1406,7 @@ exports[`<ScoreControls> renders as expected by default with a store 1`] = `
       isNextSentenceOn={true}
       isNohkanOn={true}
       isPercussionOn={true}
-      isPrevSentenceOn={true}
+      isPrevSentenceOn={false}
       isTextOn={true}
       phrases={
         Array [
@@ -2587,7 +2587,7 @@ exports[`<ScoreControls> renders as expected by default with a store 1`] = `
                   className="custom-checkbox"
                 >
                   <input
-                    checked={true}
+                    checked={false}
                     id="scorePrevSentence"
                     onChange={[Function]}
                     onKeyPress={null}

--- a/webpack/__tests__/localstorage.spec.js
+++ b/webpack/__tests__/localstorage.spec.js
@@ -1,0 +1,12 @@
+/* eslint-disable no-proto */
+import { loadState } from "../localStorage";
+
+describe("loadState", () => {
+  jest.spyOn(window.localStorage.__proto__, "getItem");
+  window.localStorage.__proto__.getItem = jest.fn();
+
+  test("it calls localStorage.getItem", () => {
+    loadState();
+    expect(localStorage.getItem).toHaveBeenCalled();
+  });
+});

--- a/webpack/__tests__/reducers.spec.js
+++ b/webpack/__tests__/reducers.spec.js
@@ -1,4 +1,9 @@
-import reducers from "../reducers";
+import reducers, { DEFAULT_STATE } from "../reducers";
+
+test("it sets default state correctly", () => {
+  const state = reducers(undefined, { type: null, payload: null });
+  expect(state).toEqual(DEFAULT_STATE);
+});
 
 test("it sets currentTime correctly", () => {
   const state = reducers(

--- a/webpack/__tests__/score.spec.jsx
+++ b/webpack/__tests__/score.spec.jsx
@@ -5,7 +5,7 @@ import { Unwrapped as UnwrappedScore } from "../components/Score";
 import { determineCurrentPhrase } from "../utils";
 
 describe("<UnwrappedScore>", () => {
-  const allToggles = {
+  const allTogglesOn = {
     isBeatOn: true,
     isTextOn: true,
     isPercussionOn: true,
@@ -15,12 +15,44 @@ describe("<UnwrappedScore>", () => {
     isNextSentenceOn: true
   };
 
+  const allTogglesOff = {
+    isBeatOn: false,
+    isTextOn: false,
+    isPercussionOn: false,
+    isNohkanOn: false,
+    isDanceOn: false,
+    isPrevSentenceOn: false,
+    isNextSentenceOn: false
+  };
+
   it("renders as expected", () => {
     const component = shallow(
       <UnwrappedScore
         phrases={phrases.phrases}
         currentTime={1193}
-        toggles={allToggles}
+        toggles={allTogglesOn}
+      />
+    );
+    expect(component).toMatchSnapshot();
+  });
+
+  it("renders as expected with all filters off", () => {
+    const component = shallow(
+      <UnwrappedScore
+        phrases={phrases.phrases}
+        currentTime={1193}
+        toggles={allTogglesOff}
+      />
+    );
+    expect(component).toMatchSnapshot();
+  });
+
+  it("renders as expected", () => {
+    const component = shallow(
+      <UnwrappedScore
+        phrases={phrases.phrases}
+        currentTime={1193}
+        toggles={allTogglesOn}
       />
     );
     expect(component).toMatchSnapshot();
@@ -44,7 +76,7 @@ describe("<UnwrappedScore>", () => {
       <UnwrappedScore
         phrases={fixturesPhrases}
         currentTime={1193}
-        toggles={allToggles}
+        toggles={allTogglesOn}
       />
     );
     expect(component).toMatchSnapshot();
@@ -55,7 +87,7 @@ describe("<UnwrappedScore>", () => {
       <UnwrappedScore
         phrases={phrases.phrases}
         currentTime={1193}
-        toggles={allToggles}
+        toggles={allTogglesOn}
       />
     );
     const calculatedPhraseIndex = determineCurrentPhrase(
@@ -67,7 +99,7 @@ describe("<UnwrappedScore>", () => {
       <UnwrappedScore
         phrases={phrases.phrases}
         currentTime={1216}
-        toggles={allToggles}
+        toggles={allTogglesOn}
       />
     );
     const calculatedPhraseIndex2 = determineCurrentPhrase(
@@ -79,7 +111,7 @@ describe("<UnwrappedScore>", () => {
       <UnwrappedScore
         phrases={phrases.phrases}
         currentTime={0}
-        toggles={allToggles}
+        toggles={allTogglesOn}
       />
     );
     const calculatedPhraseIndex3 = determineCurrentPhrase(
@@ -94,7 +126,7 @@ describe("<UnwrappedScore>", () => {
       <UnwrappedScore
         phrases={phrases.phrases}
         currentTime={1213}
-        toggles={allToggles}
+        toggles={allTogglesOn}
       />
     );
     component.instance().componentWillReceiveProps(component.instance().props);
@@ -108,7 +140,7 @@ describe("<UnwrappedScore>", () => {
       <UnwrappedScore
         phrases={phrases.phrases}
         currentTime={1213}
-        toggles={allToggles}
+        toggles={allTogglesOn}
       />
     );
     component.state().currentPhrase = null;

--- a/webpack/__tests__/scorecontrols.spec.jsx
+++ b/webpack/__tests__/scorecontrols.spec.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Provider } from "react-redux";
 import { shallow, mount } from "enzyme";
 import configureMockStore from "redux-mock-store";
+import { DEFAULT_STATE } from "../reducers";
 import ScoreControls, {
   Unwrapped as UnwrappedScoreControls
 } from "../components/ScoreControls";
@@ -13,8 +14,7 @@ describe("<ScoreControls>", () => {
 
   beforeEach(() => {
     const mockStore = configureMockStore();
-    const initialState = { currentTime: { time: 0, origin: "ScoreControls" } };
-    store = mockStore(initialState);
+    store = mockStore(DEFAULT_STATE);
     wrapper = mount(
       <Provider store={store}>
         <ScoreControls

--- a/webpack/components/ScoreControls.jsx
+++ b/webpack/components/ScoreControls.jsx
@@ -287,7 +287,14 @@ ScoreControls.defaultProps = {
 };
 
 const mapStateToProps = state => ({
-  currentTime: state.currentTime.time
+  currentTime: state.currentTime.time,
+  isBeatOn: state.toggles.isBeatOn,
+  isTextOn: state.toggles.isTextOn,
+  isPercussionOn: state.toggles.isPercussionOn,
+  isNohkanOn: state.toggles.isNohkanOn,
+  isDanceOn: state.toggles.isDanceOn,
+  isPrevSentenceOn: state.toggles.isPrevSentenceOn,
+  isNextSentenceOn: state.toggles.isNextSentenceOn
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/webpack/localStorage.js
+++ b/webpack/localStorage.js
@@ -1,0 +1,21 @@
+export const loadState = () => {
+  // returning undefined will cause redux to use the default values
+  try {
+    const serializedState = localStorage.getItem("state");
+    if (serializedState === null) {
+      return undefined;
+    }
+    return JSON.parse(serializedState);
+  } catch (err) {
+    return undefined;
+  }
+};
+
+export const saveState = state => {
+  try {
+    const serializedState = JSON.stringify(state);
+    localStorage.setItem("state", serializedState);
+  } catch (err) {
+    // write error
+  }
+};

--- a/webpack/reducers.js
+++ b/webpack/reducers.js
@@ -11,7 +11,15 @@ const DEFAULT_STATE = {
   isPlaying: false,
   startTime: 0,
   currentPhraseID: "",
-  toggles: {}
+  toggles: {
+    isBeatOn: true,
+    isTextOn: true,
+    isPercussionOn: true,
+    isNohkanOn: true,
+    isDanceOn: true,
+    isPrevSentenceOn: false,
+    isNextSentenceOn: true
+  }
 };
 
 const setCurrentTime = (state, action) =>
@@ -46,4 +54,5 @@ const rootReducer = (state = DEFAULT_STATE, action) => {
   }
 };
 
+export { DEFAULT_STATE };
 export default rootReducer;

--- a/webpack/section.jsx
+++ b/webpack/section.jsx
@@ -2,6 +2,7 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { render } from "react-dom";
 import { Provider } from "react-redux";
+import throttle from "lodash.throttle";
 
 import MasterVideo from "./components/MasterVideo";
 import Narrative from "./components/Narrative";
@@ -13,6 +14,13 @@ import ShodanTimeline from "./components/ShodanTimeline";
 
 import store from "./store";
 import contents from "./contents";
+import { saveState } from "./localStorage";
+
+store.subscribe(
+  throttle(() => {
+    saveState({ toggles: store.getState().toggles });
+  }, 2000)
+);
 
 export default class App extends Component {
   constructor(props) {

--- a/webpack/store.js
+++ b/webpack/store.js
@@ -1,8 +1,13 @@
 /* eslint-disable no-underscore-dangle */
 import { createStore } from "redux";
-import reducer from "./reducers";
+import reducer, { DEFAULT_STATE } from "./reducers";
 import { reduxDevTools } from "./utils";
+import { loadState } from "./localStorage";
 
-const store = createStore(reducer, reduxDevTools());
+const store = createStore(
+  reducer,
+  Object.assign({}, DEFAULT_STATE, loadState()),
+  reduxDevTools()
+);
 
 export default store;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4385,6 +4385,11 @@ lodash.sortby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
 
+lodash.throttle@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"
+  integrity sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ=
+
 lodash.unescape@4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/lodash.unescape/-/lodash.unescape-4.0.1.tgz#bf2249886ce514cda112fae9218cdc065211fc9c"


### PR DESCRIPTION
Closes #325.

Commit message from the main commit follows:
> There are more sophisticated ways to implement this, but they would require more of a rewrite of the way redux is implemented in the codebase (in particular, the rootReducer would need to be refactored into a more best-practice-y style).  For our simple use case, this is adequate, and efficient -- there is also scope to persist, e.g., current video position timestamps in the same way.  Serializing the whole state with JSON.stringify is not the cheapest operation computationally (this best practice would be to use thunks and redux middleware -- but see above), so it's throttled to at most once every 2 seconds, which should be more than adequate.