### PR TITLE
Apply layout and padding to anchor rather than li

### DIFF
--- a/src/_sass/components/website/mini-cards.scss
+++ b/src/_sass/components/website/mini-cards.scss
@@ -7,22 +7,14 @@
 .mini-cards__element {
   background-color: $beige-light;
   border: $border;
+  color: $brown;
   border-radius: 0.25rem;
   box-shadow: 0 0.125rem 0.25rem $black16;
-  color: $brown;
-  display: block;
   font-size: $fs-display-md;
   font-weight: $fw-regular;
-  height: 5rem;
   margin: 0.5rem;
-  overflow: hidden;
   position: relative;
-  text-decoration: none;
-  top: 0;
   transition: top $transition, box-shadow $transition;
-  width: 10rem;
-
-  @include flex-container($justify:center);
 
   &:hover {
     box-shadow: 0 0.375rem 0.75rem $black16;
@@ -32,5 +24,10 @@
   a {
     color: $green;
     text-decoration: none;
+    display: flex;
+    text-align: center;
+    height: 5rem;
+    width: 10rem;
+    @include flex-container($justify:center);
   }
 }


### PR DESCRIPTION
This should address #323: making the entire card -- not just its text -- function as a link, while also centering multi-line text.