### PR TITLE
Fix classname to match hashtags used for percussion symbols. Fixes #311

### DIFF
--- a/src/_sass/components/videoplayer/_score-percussion.scss
+++ b/src/_sass/components/videoplayer/_score-percussion.scss
@@ -15,7 +15,7 @@
 .cell--percussion-dain  { background-image: url('./images/note-dain.svg'); }
 .cell--percussion-don   { background-image: url('./images/note-don.svg'); }
 .cell--percussion-hobc  { background-image: url('./images/note-hobc.svg'); }
-.cell--percussion-hochu { background-image: url('./images/note-hochu.svg'); }
+.cell--percussion-hoch { background-image: url('./images/note-hochu.svg'); }
 .cell--percussion-howc  { background-image: url('./images/note-howc.svg'); }
 .cell--percussion-ibc   { background-image: url('./images/note-ibc.svg'); }
 .cell--percussion-iyapu { background-image: url('./images/note-iyapu.svg'); }
@@ -36,7 +36,7 @@
 .cell--percussion-wtwc  { background-image: url('./images/note-wtwc.svg'); }
 .cell--percussion-wtwt  { background-image: url('./images/note-wtwt.svg'); }
 .cell--percussion-yobc  { background-image: url('./images/note-yobc.svg'); }
-.cell--percussion-yochu { background-image: url('./images/note-yochu.svg'); }
+.cell--percussion-yoch { background-image: url('./images/note-yochu.svg'); }
 .cell--percussion-yoibc { background-image: url('./images/note-yoibc.svg'); }
 .cell--percussion-yopu  { background-image: url('./images/note-yopu.svg'); }
 .cell--percussion-yowi  { background-image: url('./images/note-yowi.svg'); }


### PR DESCRIPTION
Fixes #311 

See kokaji/noriji-1 for an example, in phrases 2 and 3.