### PR TITLE
Multiple tab containers2

### DIFF
--- a/src/assets/tabs.js
+++ b/src/assets/tabs.js
@@ -42,7 +42,7 @@ function attachTabs() {
   if (window.location.hash) activateTab(undefined, undefined, true);
 }
 
-function activateTab(hashEvent, eltID, scrollToElt = false) {
+function activateTab(hashEvent, eltID, scrollToElt) {
   /* This function is called when a tab link is clicked in any of
    * the tab containers on the page, and also when the window's hash
    * fragment changes. It activates the tab IDed in the parameter or the URL

--- a/src/assets/tabs.js
+++ b/src/assets/tabs.js
@@ -39,61 +39,58 @@ function attachTabs() {
     container.querySelector("div.wrapper").children[0].appendChild(ul);
   });
 
-  if (window.location.hash) activateTab();
+  if (window.location.hash) activateTab(undefined, undefined, true);
 }
 
-function activateTab(hashEvent, tabID) {
+function activateTab(hashEvent, eltID, scrollToElt = false) {
   /* This function is called when a tab link is clicked in any of
    * the tab containers on the page, and also when the window's hash
    * fragment changes. It activates the tab IDed in the parameter or the URL
    * and, if invoked due to a hash fragment change, scrolls the window to the
-   * top of the proper tab container. The manual scrolling is ncessary because
-   * the placement of the tab IDs (in the section body, rather than the link)
-   * otherwise will cause the browser to scroll too far.
+   * top of the proper tab container.
    */
 
-  if (tabID === "undefined" && window.location.hash)
-    tabID = window.location.hash.slice(1);
+  if (eltID === undefined && window.location.hash)
+    eltID = window.location.hash.slice(1);
 
-  var containers = document.querySelectorAll("div.tabs-container");
-  containers.forEach(function(container) {
-    var matchedSectionIndex = -1;
-    var sections = container.querySelectorAll("section");
-    sections.forEach(function(section, idx) {
-      if (section.id == tabID) matchedSectionIndex = idx;
+  var section = document.querySelector("section#" + eltID);
+  if (section) {
+    [].forEach.call(section.parentElement.children, function(_section) {
+      _section.style.display = "none";
     });
 
-    // Move on to the next container if this one doesn't contain the tab
-    if (matchedSectionIndex < 0) return;
-
-    var ul = container.querySelector("ul");
-    var lis = ul.querySelectorAll("li." + tabClass);
-    // Deactivate/activate the tabs and content panes
-    lis.forEach(function(li_, liIndex) {
-      if (liIndex != matchedSectionIndex) {
-        li_.classList.remove(tabClass + "--selected");
-        li_.setAttribute("aria-selected", "false");
-      } else {
-        li_.classList.add(tabClass + "--selected");
-        li_.setAttribute("aria-selected", "true");
-      }
-    });
-    sections.forEach(function(section_, sectionIndex) {
-      if (sectionIndex != matchedSectionIndex) section_.style.display = "none";
-      else section_.style.display = "block";
+    // Find the associated tab header link via its aria relation
+    var tabLi = document.querySelector("[aria-controls='" + eltID + "']");
+    [].forEach.call(tabLi.parentElement.children, function(_li) {
+      _li.classList.remove(tabClass + "--selected");
+      _li.setAttribute("aria-selected", "false");
     });
 
-    if (hashEvent) tabLi.scrollIntoView();
-  });
+    tabLi.classList.add(tabClass + "--selected");
+    tabLi.setAttribute("aria-selected", "true");
+    section.style.display = "block";
+
+    if (hashEvent || scrollToElt) tabLi.scrollIntoView();
+  } else {
+    // Be sure to scroll to a non-tab anchors as well, if they're clicked
+    if (scrollToElt) document.getElementById(eltID).scrollIntoView();
+  }
 }
+
+attachTabs();
 
 window.addEventListener("hashchange", activateTab, false);
 
+/* When links with hash fragments on the same page are clicked, activateTab()
+ * will run, ensuring that the proper tab will be selected and brought into
+ * focus -- or, if it the link is to a non-tab achor, its target will be
+ * scrolled into view.
+ */
 document.querySelectorAll('[href*="#"]').forEach(function(link) {
   link.addEventListener("click", function(event) {
     if (link.href == document.location.href) {
       event.preventDefault();
-      activateTab(null, link.hash.slice(1));
+      activateTab(null, link.hash.slice(1), true);
     }
   });
 });

--- a/src/assets/tabs.js
+++ b/src/assets/tabs.js
@@ -83,10 +83,17 @@ function activateTab(hashEvent, tabID) {
       else section_.style.display = "block";
     });
 
-    if (hashEvent) container.scrollIntoView();
+    if (hashEvent) tabLi.scrollIntoView();
   });
 }
 
 window.addEventListener("hashchange", activateTab, false);
 
-attachTabs();
+document.querySelectorAll('[href*="#"]').forEach(function(link) {
+  link.addEventListener("click", function(event) {
+    if (link.href == document.location.href) {
+      event.preventDefault();
+      activateTab(null, link.hash.slice(1));
+    }
+  });
+});


### PR DESCRIPTION
This *should* handle the trickiest edge cases, including clicks on links to tab hash fragments from the same page.
For testing, there are obviously no pages with multiple tab containers yet, but /shimai-dances/ is a good place to start. Another tab container group can be added via the following code (which likely also will become the template on the wiki).
```
<div class="tabs-container">
 <div class="tabs-container__links">
   <div class="wrapper">
     <div id="unique_tab_group_id_1"></div>
   </div>
 </div>
 <div class="tabs-container__content">
   <div class="wrapper">
     <section title="Tab 1 - Name" id="unique_tab_id_1">
       <p>Tab 1 content</p>
     </section>
     <section title="Tab 2 - Name" id="unique_tab_id_2">
       <p>Tab 2 content</p>
     </section>
     <section title="Tab 3 - Name" id="unique_tab_id_3">
       <p>Tab 3 content</p>
     </section>
   </div>
 </div>
</div>
```