### PR TITLE
Persist video playtime in sessionStorage

### DIFF
--- a/webpack/__tests__/__snapshots__/play.spec.jsx.snap
+++ b/webpack/__tests__/__snapshots__/play.spec.jsx.snap
@@ -1846,7 +1846,7 @@ exports[`<Play> renders as expected 1`] = `
             >
               <MasterVideo
                 currentTime={0}
-                currentTimeOrigin={null}
+                currentTimeOrigin="Kokaji"
                 isPlaying={false}
                 startTime={0}
                 tracks={

--- a/webpack/__tests__/play.spec.jsx
+++ b/webpack/__tests__/play.spec.jsx
@@ -4,20 +4,24 @@ import configureMockStore from "redux-mock-store";
 
 import App from "../play";
 import fixtures from "./__fixtures__/play.json";
+import { DEFAULT_STATE } from "../reducers";
 
 describe("<Play>", () => {
   let wrapper;
   let store;
 
   beforeEach(() => {
-    const initialState = {};
     const mockStore = configureMockStore();
 
-    store = mockStore(initialState);
+    store = mockStore(DEFAULT_STATE);
     wrapper = mount(<App store={store} {...fixtures} />);
   });
 
   it("renders as expected", () => {
     expect(wrapper).toMatchSnapshot();
+  });
+
+  it("starts at 0 if no valid origin is loaded from sessionStorage", () => {
+    expect(store.getState().currentTime.time).toBe(0);
   });
 });

--- a/webpack/__tests__/sessionStorage.spec.js
+++ b/webpack/__tests__/sessionStorage.spec.js
@@ -1,0 +1,12 @@
+/* eslint-disable no-proto */
+import { loadState } from "../sessionStorage";
+
+describe("loadState", () => {
+  jest.spyOn(window.sessionStorage.__proto__, "getItem");
+  window.sessionStorage.__proto__.getItem = jest.fn();
+
+  test("it calls sessionStorage.getItem", () => {
+    loadState();
+    expect(sessionStorage.getItem).toHaveBeenCalled();
+  });
+});

--- a/webpack/components/TimelineScrubber.jsx
+++ b/webpack/components/TimelineScrubber.jsx
@@ -41,6 +41,8 @@ class TimelineScrubber extends Component {
     // this prevents a little jankiness observable in FF
     // (related: https://bugzilla.mozilla.org/show_bug.cgi?id=1507193)
     this.updateCurrentTime = debounce(this.props.updateCurrentTime, 5);
+
+    this.updateScrubberHandle();
   }
 
   componentDidUpdate(prevProps) {

--- a/webpack/play.jsx
+++ b/webpack/play.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { render } from "react-dom";
 import { Provider } from "react-redux";
@@ -14,69 +14,87 @@ import contents from "./contents";
 import store from "./store";
 import { convertTimeToSeconds } from "./utils";
 
-const App = props => (
-  <Provider store={store}>
-    <div className="app-container">
-      <aside className="sidebar sidebar--play">
-        <div className="sidebar__header">
-          <div className="sidebar__back-link">
-            <a href="/plays" title="Plays">
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                width="7"
-                height="11"
-                viewBox="0 0 7 11"
-              >
-                <path
-                  fill="currentColor"
-                  d="M0.197894737,5.07381279 L5.31236842,0.193127854 C5.55894737,-0.0421917808 5.95894737,-0.0421917808 6.20552632,0.193127854 L6.80210526,0.762465753 C7.04842105,0.997534247 7.04868421,1.37826484 6.80315789,1.61383562 L2.74973684,5.5 L6.80289474,9.38641553 C7.04868421,9.6219863 7.04815789,10.0027169 6.80184211,10.2377854 L6.20526316,10.8071233 C5.95868421,11.0424429 5.55868421,11.0424429 5.31210526,10.8071233 L0.197894737,5.92618721 C-0.0486842105,5.69086758 -0.0486842105,5.30913242 0.197894737,5.07381279 Z"
-                />
-              </svg>
-              Back to plays
-            </a>
-          </div>
-          <h1>{props.title}</h1>
-        </div>
-        <div className="sidebar__container">
-          <Narrative narrative={props.narrative} />
-        </div>
-      </aside>
-      <main>
-        <div className="video-player">
-          <div className="video-container">
-            <MasterVideo
-              videoUrl={props.videoUrl}
-              startTime={props.startTime}
-              tracks={props.tracks}
-            />
-          </div>
-          <div className="timeline">
-            <div className="timeline__container">
-              <Acts
-                acts={props.acts}
-                duration={convertTimeToSeconds(props.videoDuration)}
-              />
-              <div className="shodan-map__container">
-                <TimelineIndicator
-                  startTime={10}
-                  currentTime={props.currentTime}
-                  duration={convertTimeToSeconds(props.videoDuration)}
-                />
-                <ShodanTimeline
-                  sections={props.sections}
-                  maxIntensity={props.maxIntensity}
-                  totalDuration={convertTimeToSeconds(props.videoDuration)}
+// eslint-disable-next-line react/prefer-stateless-function
+export default class App extends Component {
+  render() {
+    const {
+      acts,
+      currentTime,
+      maxIntensity,
+      narrative,
+      sections,
+      startTime,
+      title,
+      tracks,
+      videoDuration,
+      videoUrl
+    } = this.props;
+
+    return (
+      <Provider store={store}>
+        <div className="app-container">
+          <aside className="sidebar sidebar--play">
+            <div className="sidebar__header">
+              <div className="sidebar__back-link">
+                <a href="/plays" title="Plays">
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="7"
+                    height="11"
+                    viewBox="0 0 7 11"
+                  >
+                    <path
+                      fill="currentColor"
+                      d="M0.197894737,5.07381279 L5.31236842,0.193127854 C5.55894737,-0.0421917808 5.95894737,-0.0421917808 6.20552632,0.193127854 L6.80210526,0.762465753 C7.04842105,0.997534247 7.04868421,1.37826484 6.80315789,1.61383562 L2.74973684,5.5 L6.80289474,9.38641553 C7.04868421,9.6219863 7.04815789,10.0027169 6.80184211,10.2377854 L6.20526316,10.8071233 C5.95868421,11.0424429 5.55868421,11.0424429 5.31210526,10.8071233 L0.197894737,5.92618721 C-0.0486842105,5.69086758 -0.0486842105,5.30913242 0.197894737,5.07381279 Z"
+                    />
+                  </svg>
+                  Back to plays
+                </a>
+              </div>
+              <h1>{title}</h1>
+            </div>
+            <div className="sidebar__container">
+              <Narrative narrative={narrative} />
+            </div>
+          </aside>
+          <main>
+            <div className="video-player">
+              <div className="video-container">
+                <MasterVideo
+                  videoUrl={videoUrl}
+                  startTime={startTime}
+                  tracks={tracks}
                 />
               </div>
+              <div className="timeline">
+                <div className="timeline__container">
+                  <Acts
+                    acts={acts}
+                    duration={convertTimeToSeconds(videoDuration)}
+                  />
+                  <div className="shodan-map__container">
+                    <TimelineIndicator
+                      startTime={10}
+                      currentTime={currentTime}
+                      duration={convertTimeToSeconds(videoDuration)}
+                    />
+                    <ShodanTimeline
+                      sections={sections}
+                      maxIntensity={maxIntensity}
+                      totalDuration={convertTimeToSeconds(videoDuration)}
+                    />
+                  </div>
+                </div>
+                {/* These have to update based on current time */}
+                <IntermediaTable play={title} sections={sections} />
+              </div>
             </div>
-            {/* These have to update based on current time */}
-            <IntermediaTable play={props.title} sections={props.sections} />
-          </div>
+          </main>
         </div>
-      </main>
-    </div>
-  </Provider>
-);
+      </Provider>
+    );
+  }
+}
 
 App.propTypes = {
   title: PropTypes.string,
@@ -149,5 +167,3 @@ if (!module.parent) {
     render(<App {...props} />, document.getElementById("play"));
   });
 }
-
-export default App;

--- a/webpack/reducers.js
+++ b/webpack/reducers.js
@@ -7,7 +7,7 @@ import {
 } from "./actions";
 
 const DEFAULT_STATE = {
-  currentTime: { time: 0, origin: null },
+  currentTime: { time: 0, origin: "DEFAULT_STATE" },
   isPlaying: false,
   startTime: 0,
   currentPhraseID: "",

--- a/webpack/sessionStorage.js
+++ b/webpack/sessionStorage.js
@@ -1,0 +1,21 @@
+export const loadState = () => {
+  // returning undefined will cause redux to use the default values
+  try {
+    const serializedState = sessionStorage.getItem("state");
+    if (serializedState === null) {
+      return undefined;
+    }
+    return JSON.parse(serializedState);
+  } catch (err) {
+    return undefined;
+  }
+};
+
+export const saveState = state => {
+  try {
+    const serializedState = JSON.stringify(state);
+    sessionStorage.setItem("state", serializedState);
+  } catch (err) {
+    // write error
+  }
+};

--- a/webpack/store.js
+++ b/webpack/store.js
@@ -2,11 +2,17 @@
 import { createStore } from "redux";
 import reducer, { DEFAULT_STATE } from "./reducers";
 import { reduxDevTools } from "./utils";
-import { loadState } from "./localStorage";
+import { loadState as loadStateFromLocalStorage } from "./localStorage";
+import { loadState as loadStateFromSessionStorage } from "./sessionStorage";
 
 const store = createStore(
   reducer,
-  Object.assign({}, DEFAULT_STATE, loadState()),
+  Object.assign(
+    {},
+    DEFAULT_STATE,
+    loadStateFromLocalStorage(),
+    loadStateFromSessionStorage()
+  ),
   reduxDevTools()
 );
 


### PR DESCRIPTION
The behaviour implemented here should be as follows:
* when navigating from level 1 to level 2, the current video index is preserved
* when navigating from level 2 to level 1, the current video index is preserved
* when navigating from one shōdan to another at level 2, the video index is reset to the beginning of the shōdan
* when navigating to a different play, the video index is reset to 0 (level 1) or the beginning of the shōdan (level 2)
* video indices are preserved only within the lifetime of a single tab -- new tabs start at 0 (level 1) or the beginning of the shōdan (level 2)

I think this is intuitive and (broadly) expected behaviour.  Unless there are bugs in respect of the above, I'm inclined to consider additional behaviour handling to constitute an additional feature at this point.

Closes: #327.