### PR TITLE
Ensure catalog data is available on `yarn dev`

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build":
       "bundle exec jekyll clean && bundle exec jekyll build && node_modules/.bin/webpack -p --mode production",
     "dev":
-      "if [ ! -d \"data\" ]; then yarn parse:catalog; yarn parse; fi && yarn concurrently \"node_modules/.bin/webpack --mode development --watch\" \"bundle exec jekyll serve\"",
+      "if [ ! -d \"data\" ]; then yarn parse; fi && if [ ! -d \"src/_data\" ]; then yarn parse:catalog; fi && yarn concurrently \"node_modules/.bin/webpack --mode development --watch\" \"bundle exec jekyll serve\"",
     "lint":
       "node_modules/.bin/eslint webpack/**/*.{js,jsx} webpack/*.{js,jsx} --quiet",
     "precommit": "lint-staged",


### PR DESCRIPTION
This change should have been made when I reorganized the webpack configutation.  Note: production builds are not affected.