### PR TITLE
Open video at time

### DIFF
--- a/webpack/__tests__/__snapshots__/play.spec.jsx.snap
+++ b/webpack/__tests__/__snapshots__/play.spec.jsx.snap
@@ -1266,12 +1266,11 @@ exports[`<Play> renders as expected 1`] = `
   startTime={0}
   store={
     Object {
-      "clearActions": [Function],
       "dispatch": [Function],
-      "getActions": [Function],
       "getState": [Function],
       "replaceReducer": [Function],
       "subscribe": [Function],
+      Symbol(observable): [Function],
     }
   }
   title="Kokaji"

--- a/webpack/__tests__/play.spec.jsx
+++ b/webpack/__tests__/play.spec.jsx
@@ -1,19 +1,14 @@
 import React from "react";
 import { mount } from "enzyme";
-import configureMockStore from "redux-mock-store";
 
 import App from "../play";
 import fixtures from "./__fixtures__/play.json";
-import { DEFAULT_STATE } from "../reducers";
+import store from "../store";
 
 describe("<Play>", () => {
   let wrapper;
-  let store;
 
   beforeEach(() => {
-    const mockStore = configureMockStore();
-
-    store = mockStore(DEFAULT_STATE);
     wrapper = mount(<App store={store} {...fixtures} />);
   });
 
@@ -23,5 +18,20 @@ describe("<Play>", () => {
 
   it("starts at 0 if no valid origin is loaded from sessionStorage", () => {
     expect(store.getState().currentTime.time).toBe(0);
+  });
+
+  it("sets currentTime appropriately based on URL frag", () => {
+    expect(store.getState().currentTime).toEqual({
+      time: 0,
+      origin: "Kokaji"
+    });
+
+    window.location.hash = "#startTime=1000";
+    window.dispatchEvent(new HashChangeEvent("hashchange"));
+
+    expect(store.getState().currentTime).toEqual({
+      time: 1000,
+      origin: "URL_FRAG"
+    });
   });
 });

--- a/webpack/__tests__/section.spec.jsx
+++ b/webpack/__tests__/section.spec.jsx
@@ -6,6 +6,7 @@ import App from "../section";
 import fixtures from "./__fixtures__/section.json";
 import fixturesNoPhrases from "./__fixtures__/section-no-phrases.json";
 import fixturesFirstAndLast from "./__fixtures__/multiple-sections.json";
+import _store from "../store";
 
 describe("<Section>", () => {
   let wrapper;
@@ -115,5 +116,21 @@ describe("<Section> that is last in play", () => {
     const wrapper = mount(<App store={store} {...fixturesFirstAndLast[1]} />);
 
     expect(wrapper).toMatchSnapshot();
+  });
+});
+
+describe("<Section> with a URL frag", () => {
+  it("sets currentTime appropriately based on URL frag", () => {
+    mount(<App store={_store} {...fixtures} />);
+    _store.dispatch = jest.fn();
+
+    window.location.hash = "#startTime=1000";
+    window.dispatchEvent(new HashChangeEvent("hashchange"));
+
+    const payload = {
+      payload: { time: 1000, origin: "URL_FRAG" },
+      type: "SET_CURRENT_TIME"
+    };
+    expect(_store.dispatch).toHaveBeenCalledWith(payload);
   });
 });

--- a/webpack/__tests__/utils.spec.jsx
+++ b/webpack/__tests__/utils.spec.jsx
@@ -37,14 +37,16 @@ describe("convertTimeToSeconds", () => {
     expect(convertTimeToSeconds(time)).toEqual(expectedTime);
   });
 
-  test("it defaults to 0 for invalid times", () => {
-    const time = "01:01:90.001";
-    expect(convertTimeToSeconds(time)).toEqual(0);
+  test("it correctly converts time expressed in mm:ss to seconds", () => {
+    const time = "42:17";
+    const expectedTime = 2537;
+    expect(convertTimeToSeconds(time)).toEqual(expectedTime);
   });
 
-  test("it defaults to 0 for bad formatted times", () => {
-    const time = "Dec 1st 2017 01:01:90.001";
-    expect(convertTimeToSeconds(time)).toEqual(0);
+  test("it correctly converts time expressed in ss to seconds", () => {
+    const time = "17";
+    const expectedTime = 17;
+    expect(convertTimeToSeconds(time)).toEqual(expectedTime);
   });
 });
 

--- a/webpack/__tests__/utils.spec.jsx
+++ b/webpack/__tests__/utils.spec.jsx
@@ -4,7 +4,8 @@ import {
   convertTimeToSeconds,
   convertSecondsToHhmmss,
   fillGrid,
-  reduxDevTools
+  reduxDevTools,
+  validateTimestamp
 } from "../utils";
 import phrases from "./__fixtures__/phrases.json";
 
@@ -77,5 +78,25 @@ describe("reduxDevTools", () => {
   test("it returns nothing if the Redux dev tools are unavailable", () => {
     window.__REDUX_DEVTOOLS_EXTENSION__ = null;
     expect(reduxDevTools()).toBe(null);
+  });
+});
+
+describe("validateTimestamp", () => {
+  test("it correctly returns simple integers", () => {
+    const timestamp = "3600";
+    const expectedReturn = 3600;
+    expect(validateTimestamp(timestamp)).toBe(expectedReturn);
+  });
+
+  test("it correctly returns hh:mm:ss-format timestamps as seconds", () => {
+    const timestamp = "1:12:54";
+    const expectedReturn = 4374;
+    expect(validateTimestamp(timestamp)).toBe(expectedReturn);
+  });
+
+  test("it returns false for unparseable timestamps", () => {
+    const timestamp = "abc";
+    const expectedReturn = false;
+    expect(validateTimestamp(timestamp)).toBe(expectedReturn);
   });
 });

--- a/webpack/play.jsx
+++ b/webpack/play.jsx
@@ -14,10 +14,23 @@ import ShodanTimeline from "./components/ShodanTimeline";
 import contents from "./contents";
 import store from "./store";
 import { setCurrentTime } from "./actionCreators";
-import { convertTimeToSeconds } from "./utils";
+import {
+  convertTimeToSeconds,
+  parseUrlFragment,
+  validateTimestamp
+} from "./utils";
 import { saveState as saveStateToSessionStorage } from "./sessionStorage";
 
 export default class App extends Component {
+  static updateTimeFromUrlFrag() {
+    // check for a URL fragment of the form `#startTime=<timestamp>` and
+    // proceed accordingly
+    const urlFragParams = parseUrlFragment();
+    const seekToTime = validateTimestamp(urlFragParams.startTime); // returns false on absent or unparseable timestamp
+    if (seekToTime)
+      store.dispatch(setCurrentTime({ time: seekToTime, origin: "URL_FRAG" }));
+  }
+
   constructor(props) {
     super(props);
 
@@ -40,6 +53,11 @@ export default class App extends Component {
     if (storedOrigin.split("/")[0] !== origin) {
       store.dispatch(setCurrentTime({ time: currentTime, origin }));
     }
+
+    // set up a listener for hashchange events, and then process any URL frag that
+    //  may have been included at page-load time
+    window.addEventListener("hashchange", App.updateTimeFromUrlFrag, false);
+    App.updateTimeFromUrlFrag();
   }
 
   render() {

--- a/webpack/section.jsx
+++ b/webpack/section.jsx
@@ -17,8 +17,18 @@ import contents from "./contents";
 import { setCurrentTime } from "./actionCreators";
 import { saveState as saveStateToLocalStorage } from "./localStorage";
 import { saveState as saveStateToSessionStorage } from "./sessionStorage";
+import { parseUrlFragment, validateTimestamp } from "./utils";
 
 export default class App extends Component {
+  static updateTimeFromUrlFrag() {
+    // check for a URL fragment of the form `#startTime=<timestamp>` and
+    // proceed accordingly
+    const urlFragParams = parseUrlFragment();
+    const seekToTime = validateTimestamp(urlFragParams.startTime); // returns false on absent or unparseable timestamp
+    if (seekToTime)
+      store.dispatch(setCurrentTime({ time: seekToTime, origin: "URL_FRAG" }));
+  }
+
   constructor(props) {
     super(props);
     this.state = {
@@ -53,6 +63,9 @@ export default class App extends Component {
     if (play !== playName || ![sectionName, undefined].includes(section)) {
       store.dispatch(setCurrentTime({ time: startTime, origin }));
     }
+
+    window.addEventListener("hashchange", App.updateTimeFromUrlFrag, false);
+    App.updateTimeFromUrlFrag();
   }
 
   getSectionURLS() {

--- a/webpack/utils.js
+++ b/webpack/utils.js
@@ -10,9 +10,8 @@ export function getTime(element) {
 
 // Converts time from hh:mm:ss to seconds
 export function convertTimeToSeconds(hhmmss) {
-  const timeFormat = `01/01/1970 ${hhmmss} GMT`;
-  const time = Date.parse(timeFormat);
-  return time / 1e3 || 0.0;
+  const [ss, mm, hh] = hhmmss.split(":").reverse();
+  return Date.UTC(1970, 0, 1, +hh || 0, +mm || 0, +ss || 0) / 1000;
 }
 
 // Converts time in seconds to hh:mm:ss

--- a/webpack/utils.js
+++ b/webpack/utils.js
@@ -83,3 +83,24 @@ export function reduxDevTools() {
     window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__()
   );
 }
+
+// Parse URL Fragments of the form `#key1=val1&key2=val2...` and returns
+//  an object of the form `{ key1: val1, key2: val2 ... }`.
+export function parseUrlFragment() {
+  return window.location.hash
+    .slice(1)
+    .split("&")
+    .reduce((accumulator, kvPair) => {
+      const [key, value] = kvPair.split("=");
+      return Object.assign({ [key]: value }, accumulator);
+    }, {});
+}
+
+// Given an integer value or a timestamp of the form <<hh:>mm:>ss, returns
+//  an integer value representing the timestamp in seconds.
+export function validateTimestamp(timestamp) {
+  if (!Number.isNaN(Number(timestamp))) return Number(timestamp);
+  if (/^(?:\d{1,2}:)?(?:\d{2}:)?\d{2}$/.exec(timestamp))
+    return convertTimeToSeconds(timestamp);
+  return false;
+}


### PR DESCRIPTION
Level 1 and level 2 video pages now accept a `key=value` pair as a parameter in the URL fragment identifier of the following form: `#startTime=<timestamp>`.  `timestamp` can be in seconds, or in the `<<hh:>mm:>ss` format (hours and minutes are optional)[1].

Notes:
1) At level 2, if the URL frag specifies a time index outside the shōdan, the app behaves in a way consistent with the behaviour of the master video scrubber.
2) I notice now that the original feature request issue is unclear about support for level 1 or level 2, but we have both now, anyway.

Closes #189.
Closes #312.

[1] In fact, it can accept any number format Javascript can understand; try, e.g. `1e3`, `0xFF`, or `0o100`... :rofl:  Suggesting we don't document this fact :smile: