### PR TITLE
Feature/image captions

### DIFF
--- a/src/_includes/image-no-background.html
+++ b/src/_includes/image-no-background.html
@@ -1,3 +1,6 @@
-<div class="image-container--no-background">
+<figure class="image-container--no-background">
   <img src="{{ include.src }}" alt="">
-</div>
+  {% if include.caption %}
+  <figcaption><span>{{ include.caption }}</span></figcaption>
+  {% endif %}
+</figure>

--- a/src/_includes/image-no-background.html
+++ b/src/_includes/image-no-background.html
@@ -1,6 +1,6 @@
 <figure class="image-container--no-background">
   <img src="{{ include.src }}" alt="">
   {% if include.caption %}
-  <figcaption><span>{{ include.caption }}</span></figcaption>
+  <figcaption class="figure-caption">{{ include.caption }}</figcaption>
   {% endif %}
 </figure>

--- a/src/_includes/image.html
+++ b/src/_includes/image.html
@@ -3,6 +3,6 @@
     <img src="{{ include.src }}" alt="">
   </div>
   {% if include.caption %}
-  <figcaption><span>{{ include.caption }}</span></figcaption>
+  <figcaption class="figure-caption">{{ include.caption }}</figcaption>
   {% endif %}
 </figure>

--- a/src/_includes/image.html
+++ b/src/_includes/image.html
@@ -1,5 +1,8 @@
-<div class="image-container">
+<figure class="image-container">
   <div class="wrapper">
     <img src="{{ include.src }}" alt="">
   </div>
-</div>
+  {% if include.caption %}
+  <figcaption><span>{{ include.caption }}</span></figcaption>
+  {% endif %}
+</figure>

--- a/src/_sass/layouts/_layout-commons.scss
+++ b/src/_sass/layouts/_layout-commons.scss
@@ -50,7 +50,7 @@
 }
 
 .figure-caption {
-  padding: 2rem 0;
+  padding: 2rem 0 0 0;
   color: #4a4036;
   font-family: "Source Serif Pro", Georgia, serif;
   font-size: 1rem;

--- a/src/_sass/layouts/_layout-commons.scss
+++ b/src/_sass/layouts/_layout-commons.scss
@@ -48,3 +48,10 @@
   margin: 2rem 0;
   padding: 2rem 0;
 }
+
+.figure-caption {
+  padding: 2rem 0;
+  color: #4a4036;
+  font-family: "Source Serif Pro", Georgia, serif;
+  font-size: 1rem;
+}


### PR DESCRIPTION
Addresses #319. Caption text, like the text in `<h7>` tags in `/staging/props`, would need to be placed into the `caption=` attribute of the `image-no-background.html` (or `image.html`) template (see example below). Some notes:
  - Because the caption is set via an attribute, proper quote escaping needs to be done, which gets a bit cumbersome when the caption has links in it. But it should be manageable.
  - The wiki would need to be updated to reflect these updates to the templates and the few existing instances of manual caption texts would need to be migrated to this new scheme.
  - Encouraging more prevalent use of `alt=` tags for images is considered out of scope.

An example:
```
{% include image-no-background.html src="/assets/images/Okura-dwelling.png" 
caption="Dwelling property for Hashitomi. Ōkura ryū tsukurimono hiroku (Ōkura School Secret Records on Stage Properties) by Yamamura Kyūzaemon. Noh Theater Research Institute of Hōsei University.
Available at <a href=\"http://www.dh-jac.net/db1/books/results1024.php?f1=nohken-y17-29&f12=1&enter=jparc&skip=17&-max=1&enter=jparc\">JPARC</a> or <a href=\"https://nohken.ws.hosei.ac.jp/nohken_material/htmls/index/pages/y17/29.html\">Hōsei University.</a>"
%}
```