### PR TITLE
Feature/audio player

### DIFF
--- a/src/_includes/audio-clip.html
+++ b/src/_includes/audio-clip.html
@@ -1,0 +1,28 @@
+{% assign player_id = include.src | append: "_player" %}
+{% assign controls_id = include.src | append: "_controls" %}
+
+<li class="mini-cards__element">
+  <audio id="{{ player_id }}">
+    <source src="{{ include.src }}" type="audio/mpeg">
+    No browser audio support.
+  </audio>
+  <div id="{{ controls_id }}">{{include.text}}</div> 
+</li>
+<script>
+  var controls = document.getElementById("{{ controls_id }}");
+  var player = document.getElementById("{{ player_id }}");
+
+  player.onended = function() {
+    controls.classList.remove('audio_playing');
+  }
+
+  controls.onclick = function() {
+    if (controls.classList.contains('audio_playing')) {
+      controls.classList.remove('audio_playing');
+      player.pause();
+    } else {
+      controls.classList.add('audio_playing');
+      player.play();
+    }
+  }
+</script>

--- a/src/_includes/audio-clip.html
+++ b/src/_includes/audio-clip.html
@@ -6,22 +6,26 @@
     <source src="{{ include.src }}" type="audio/mpeg">
     No browser audio support.
   </audio>
-  <div id="{{ controls_id }}">{{include.text}}</div> 
+  <div id="{{ controls_id }}" class="audio-label audio-player">{{include.text}}</div>
 </li>
+
 <script>
   var controls = document.getElementById("{{ controls_id }}");
   var player = document.getElementById("{{ player_id }}");
 
   player.onended = function() {
-    controls.classList.remove('audio_playing');
+    controls.classList.remove('audio-playing');
+    controls.classList.add('audio-player');
   }
 
   controls.onclick = function() {
-    if (controls.classList.contains('audio_playing')) {
-      controls.classList.remove('audio_playing');
+    if (controls.classList.contains('audio-playing')) {
+      controls.classList.remove('audio-playing');
+      controls.classList.add('audio-player');
       player.pause();
     } else {
-      controls.classList.add('audio_playing');
+      controls.classList.remove('audio-player');
+      controls.classList.add('audio-playing');
       player.play();
     }
   }

--- a/src/_sass/commons/_variables-colors.scss
+++ b/src/_sass/commons/_variables-colors.scss
@@ -36,6 +36,7 @@ $brown80:       rgba($brown, 0.80);
 
 $beige-dark:  #f2ece6;
 $beige-light: #f9f6f3;
+$beige-darker: #f2dfcb;
 
 $bg-color: $beige-dark;
 $border-color: $brown16;

--- a/src/_sass/components/website/mini-cards.scss
+++ b/src/_sass/components/website/mini-cards.scss
@@ -21,13 +21,18 @@
     top: -0.125rem;
   }
 
-  a {
+  a, div {
     color: $green;
+    cursor: pointer;
     text-decoration: none;
     display: flex;
     text-align: center;
     height: 5rem;
     width: 10rem;
     @include flex-container($justify:center);
+  }
+
+  .audio_playing {
+    background-color: $beige-dark;
   }
 }

--- a/src/_sass/components/website/mini-cards.scss
+++ b/src/_sass/components/website/mini-cards.scss
@@ -13,7 +13,13 @@
   font-size: $fs-display-md;
   font-weight: $fw-regular;
   margin: 0.5rem;
+  height: 5rem;
+  width: 10rem;
   position: relative;
+  cursor: pointer;
+  display: flex;
+  text-align: center;
+  @include flex-container($justify:center);
   transition: top $transition, box-shadow $transition;
 
   &:hover {
@@ -21,18 +27,28 @@
     top: -0.125rem;
   }
 
-  a, div {
+  a, .audio-label {
     color: $green;
-    cursor: pointer;
     text-decoration: none;
-    display: flex;
-    text-align: center;
     height: 5rem;
     width: 10rem;
     @include flex-container($justify:center);
+    z-index: 1;
   }
 
-  .audio_playing {
-    background-color: $beige-dark;
+  .audio-player::after, .audio-playing:after {
+    font-family: 'FontAwesome';
+    font-size: 5rem;
+    color: $beige-darker;
+    position: absolute;
+    z-index: -1;
   }
+  .audio-player:after {
+    left: 3.5rem;
+    content: "\f04b";
+  }
+  .audio-playing:after {
+    content: "\f04c";
+  }
+
 }

--- a/src/_sass/components/website/mini-cards.scss
+++ b/src/_sass/components/website/mini-cards.scss
@@ -36,18 +36,18 @@
     z-index: 1;
   }
 
-  .audio-player::after, .audio-playing:after {
+  .audio-player::after, .audio-playing::after {
     font-family: 'FontAwesome';
     font-size: 5rem;
     color: $beige-darker;
     position: absolute;
     z-index: -1;
   }
-  .audio-player:after {
+  .audio-player::after {
     left: 3.5rem;
     content: "\f04b";
   }
-  .audio-playing:after {
+  .audio-playing::after {
     content: "\f04c";
   }
 


### PR DESCRIPTION
Addresses #320. Assumption is that most sound examples are quite short, so basic "drum pad" style play/pause controls within mini-cards would be sufficient. Example here:
http://ec2-3-14-12-54.us-east-2.compute.amazonaws.com/music/taiko/#Kakegoe
(warning: it plays music when clicked!)

I wasn't satisfied with any of the existing site palette colors for the play/pause underlay graphic, so added another one, but other suggestions are welcome.

Audio player minicards can be added to a set of minicards (within a `<ul class="mini-cards__container">` element) by inserting the following template:
`{% include audio-clip.html src="link_to_.mp3" text="yo" %}`
where a `<li class="mini-cards__element">` would otherwise be used.
