### PR TITLE
Consistent filter behavior

### DIFF
--- a/src/_includes/filter-card.html
+++ b/src/_includes/filter-card.html
@@ -1,4 +1,4 @@
-<a href="./{{include.slug}}" data-pills="{{include.pills}}" class="filters__card" style="background-image:url('/assets/images/{{include.images}}/{{include.slug}}.jpg')">
+<a href="./{{include.slug}}" target="_blank" data-pills="{{include.pills}}" class="filters__card" style="background-image:url('/assets/images/{{include.images}}/{{include.slug}}.jpg')">
   <h6 class="filters__card-title">{{ include.title }}</h6>
   <ul class="filters__pills-container">
     {% assign pills = include.pills | split: ',' %}

--- a/src/_sass/components/_checkbox.scss
+++ b/src/_sass/components/_checkbox.scss
@@ -28,7 +28,7 @@
 
     &::before {
       background-color: $beige-dark;
-      border-color: $brown16;
+      border-color: $brown80;
       border-radius: 0.125rem;
       border-style: solid;
       border-width: 0.0625rem;
@@ -49,7 +49,7 @@
     }
 
     .custom-checkbox__text {
-      color: $brown48;
+      color: $brown;
     }
   }
 

--- a/src/_sass/components/_checkbox.scss
+++ b/src/_sass/components/_checkbox.scss
@@ -10,6 +10,7 @@
     font-size: $fs-display-xs;
     line-height: 1.25;
     padding-left: 1.375rem;
+    color: $brown;
 
     span {
       display: inline-block;
@@ -67,7 +68,7 @@
   input[type="checkbox"]:checked + label::before,
   input[type="checkbox"]:indeterminate + label::before {
     background-color: $green;
-    border-color: $green;
+    border-color: $brown80;
   }
 
   input[type="checkbox"]:checked + label::after {


### PR DESCRIPTION
Note that this includes the styling updates from PR #383 (first commit) and actually updates the filter label and checkbox styling a bit (last commit), so that the appearance of checkboxes and labels is consistent across the catalog and level 2 filters.
The actual functionality change (second commit) just makes all clicked catalog cards open in a new tab, which hopefully should address #324 by taking the back button out of the equation.