### PR TITLE
Consistent filter behavior

### DIFF
--- a/src/_includes/filter-card.html
+++ b/src/_includes/filter-card.html
@@ -1,4 +1,4 @@
-<a href="./{{include.slug}}" data-pills="{{include.pills}}" class="filters__card" style="background-image:url('/assets/images/{{include.images}}/{{include.slug}}.jpg')">
+<a href="./{{include.slug}}" target="_blank" data-pills="{{include.pills}}" class="filters__card" style="background-image:url('/assets/images/{{include.images}}/{{include.slug}}.jpg')">
   <h6 class="filters__card-title">{{ include.title }}</h6>
   <ul class="filters__pills-container">
     {% assign pills = include.pills | split: ',' %}

--- a/src/_sass/components/_checkbox.scss
+++ b/src/_sass/components/_checkbox.scss
@@ -10,6 +10,7 @@
     font-size: $fs-display-xs;
     line-height: 1.25;
     padding-left: 1.375rem;
+    color: $brown;
 
     span {
       display: inline-block;
@@ -67,7 +68,7 @@
   input[type="checkbox"]:checked + label::before,
   input[type="checkbox"]:indeterminate + label::before {
     background-color: $green;
-    border-color: $green;
+    border-color: $brown80;
   }
 
   input[type="checkbox"]:checked + label::after {


### PR DESCRIPTION
The new functionality in this PR makes all of the shōdan catalog cards open in a new tab, which hopefully should address issue #324 by taking the back button out of the equation.
This PR also includes modifications to the filter option text+checkbox styling, which will affect both the shōdan catalog as well as the level 2 filters (last modified in PR #383).