### PR TITLE
Move audio play/pause indicator to bottom right of card

### DIFF
--- a/src/_sass/components/website/mini-cards.scss
+++ b/src/_sass/components/website/mini-cards.scss
@@ -38,17 +38,18 @@
 
   .audio-player::after, .audio-playing::after {
     font-family: 'FontAwesome';
-    font-size: 5rem;
-    color: $beige-darker;
+    font-size: 1.5rem;
+    color: $green64;
     position: absolute;
     z-index: -1;
+    right: .25rem;
+    bottom: .1rem;
   }
   .audio-player::after {
-    left: 3.5rem;
-    content: "\f04b";
+    content: $fa-var-play;
   }
   .audio-playing::after {
-    content: "\f04c";
+    content: $fa-var-pause;
   }
 
 }


### PR DESCRIPTION
The play/pause icons should now be below and to the right of any single-line card label, and also won't overlap with any currently existing two-line card labels. The icons are also darker in color now, and the variable names for the fontawesome play/pause icons are used.
Example here:
http://ec2-3-14-12-54.us-east-2.compute.amazonaws.com/music/taiko/