### PR TITLE
Fix Sentence Counts and Prev/Next Sentence Buttons

### DIFF
--- a/src/_sass/components/videoplayer/_score-controls.scss
+++ b/src/_sass/components/videoplayer/_score-controls.scss
@@ -28,6 +28,11 @@ $score-checkbox-height: 1.5rem;
   background: none;
   cursor: pointer;
   @include text(md);
+
+  &:disabled {
+    cursor: default;
+    opacity: .4;
+  }
 }
 
 .sentence-control__prev {

--- a/webpack/__tests__/__snapshots__/scorecontrols.spec.jsx.snap
+++ b/webpack/__tests__/__snapshots__/scorecontrols.spec.jsx.snap
@@ -9,6 +9,7 @@ exports[`<ScoreControls> renders as expected by default 1`] = `
   >
     <button
       className="sentence-control__prev"
+      disabled={true}
       onClick={[Function]}
     >
       <i
@@ -33,6 +34,7 @@ exports[`<ScoreControls> renders as expected by default 1`] = `
     </div>
     <button
       className="sentence-control__next"
+      disabled={false}
       onClick={[Function]}
     >
       <i
@@ -260,6 +262,7 @@ exports[`<ScoreControls> renders as expected by default at the end of the durati
   >
     <button
       className="sentence-control__prev"
+      disabled={false}
       onClick={[Function]}
     >
       <i
@@ -284,6 +287,7 @@ exports[`<ScoreControls> renders as expected by default at the end of the durati
     </div>
     <button
       className="sentence-control__next"
+      disabled={true}
       onClick={[Function]}
     >
       <i
@@ -2299,6 +2303,7 @@ exports[`<ScoreControls> renders as expected by default with a store 1`] = `
         >
           <button
             className="sentence-control__prev"
+            disabled={true}
             onClick={[Function]}
           >
             <i
@@ -2323,6 +2328,7 @@ exports[`<ScoreControls> renders as expected by default with a store 1`] = `
           </div>
           <button
             className="sentence-control__next"
+            disabled={false}
             onClick={[Function]}
           >
             <i

--- a/webpack/__tests__/__snapshots__/scorecontrols.spec.jsx.snap
+++ b/webpack/__tests__/__snapshots__/scorecontrols.spec.jsx.snap
@@ -26,7 +26,7 @@ exports[`<ScoreControls> renders as expected by default 1`] = `
       <span
         className="sentence-control__current"
       >
-        1
+        4
         /
         3
       </span>
@@ -1395,11 +1395,12 @@ exports[`<ScoreControls> renders as expected by default with a store 1`] = `
         },
       ]
     }
+    startTime={1192}
     updateScoreToggles={[MockFunction]}
     updateStartTime={[MockFunction]}
   >
     <ScoreControls
-      currentTime={0}
+      currentTime={1192}
       duration={2000}
       isBeatOn={true}
       isDanceOn={true}
@@ -2286,7 +2287,7 @@ exports[`<ScoreControls> renders as expected by default with a store 1`] = `
           },
         ]
       }
-      startTime={0}
+      startTime={1192}
       updateScoreToggles={[Function]}
       updateStartTime={[Function]}
     >
@@ -2342,12 +2343,12 @@ exports[`<ScoreControls> renders as expected by default with a store 1`] = `
           >
             <Connect(TimelineScrubber)
               duration={2000}
-              startTime={0}
+              startTime={1192}
             >
               <TimelineScrubber
-                currentTime={0}
+                currentTime={1192}
                 duration={2000}
-                startTime={0}
+                startTime={1192}
                 updateCurrentTime={[Function]}
               >
                 <div

--- a/webpack/__tests__/scorecontrols.spec.jsx
+++ b/webpack/__tests__/scorecontrols.spec.jsx
@@ -113,4 +113,51 @@ describe("<ScoreControls>", () => {
     button.simulate("click");
     expect(store.getActions()[1]).toEqual(action);
   });
+
+  it("ignores prev button when currentTime is outside section (earlier)", () => {
+    const mockStore = configureMockStore();
+    const defaultState = DEFAULT_STATE;
+    defaultState.currentTime.time = 0;
+    store = mockStore(defaultState);
+    wrapper = mount(
+      <Provider store={store}>
+        <ScoreControls
+          phrases={phrases}
+          duration={2000}
+          startTime={phrases[0].startTime.value}
+          updateScoreToggles={jest.fn()}
+          updateStartTime={jest.fn()}
+        />
+      </Provider>
+    );
+
+    const action = undefined;
+    const button = wrapper.find("button.sentence-control__prev").first();
+    button.simulate("click");
+    expect(store.getActions()[1]).toEqual(action);
+  });
+
+  it("ignores next button when currentTime is outside section (later)", () => {
+    const mockStore = configureMockStore();
+    const defaultState = DEFAULT_STATE;
+    const duration = 2000;
+    defaultState.currentTime.time = phrases[0].startTime.value + duration + 10;
+    store = mockStore(defaultState);
+    wrapper = mount(
+      <Provider store={store}>
+        <ScoreControls
+          phrases={phrases}
+          duration={duration}
+          startTime={phrases[0].startTime.value}
+          updateScoreToggles={jest.fn()}
+          updateStartTime={jest.fn()}
+        />
+      </Provider>
+    );
+
+    const action = undefined;
+    const button = wrapper.find("button.sentence-control__next").first();
+    button.simulate("click");
+    expect(store.getActions()[1]).toEqual(action);
+  });
 });

--- a/webpack/__tests__/scorecontrols.spec.jsx
+++ b/webpack/__tests__/scorecontrols.spec.jsx
@@ -14,11 +14,14 @@ describe("<ScoreControls>", () => {
 
   beforeEach(() => {
     const mockStore = configureMockStore();
-    store = mockStore(DEFAULT_STATE);
+    const defaultState = DEFAULT_STATE;
+    defaultState.currentTime.time = phrases[0].startTime.value;
+    store = mockStore(defaultState);
     wrapper = mount(
       <Provider store={store}>
         <ScoreControls
           phrases={phrases}
+          startTime={phrases[0].startTime.value}
           duration={2000}
           updateScoreToggles={jest.fn()}
           updateStartTime={jest.fn()}

--- a/webpack/__tests__/scorecontrols.spec.jsx
+++ b/webpack/__tests__/scorecontrols.spec.jsx
@@ -79,6 +79,22 @@ describe("<ScoreControls>", () => {
   });
 
   it("handles prev button", () => {
+    const mockStore = configureMockStore();
+    const defaultState = DEFAULT_STATE;
+    defaultState.currentTime.time = phrases[1].startTime.value;
+    store = mockStore(defaultState);
+    wrapper = mount(
+      <Provider store={store}>
+        <ScoreControls
+          phrases={phrases}
+          duration={2000}
+          startTime={phrases[0].startTime.value}
+          updateScoreToggles={jest.fn()}
+          updateStartTime={jest.fn()}
+        />
+      </Provider>
+    );
+
     const action = {
       type: "SET_CURRENT_TIME",
       payload: { time: phrases[0].startTime.value, origin: "ScoreControls" }

--- a/webpack/components/ScoreControls.jsx
+++ b/webpack/components/ScoreControls.jsx
@@ -66,10 +66,11 @@ class ScoreControls extends Component {
         .findIndex(phrase => currentTime >= phrase.startTime.value) +
         1);
 
-    const nextPhraseIndex = Math.min(
-      currentPhraseIndex + 1,
-      phrases.length - 1
-    );
+    const lastPhraseStartTime = phrases[phrases.length - 1].startTime.value;
+    const nextPhraseIndex =
+      currentTime >= lastPhraseStartTime
+        ? null
+        : Math.min(currentPhraseIndex + 1, phrases.length - 1);
     const prevPhraseIndex = Math.max(currentPhraseIndex - 1, 0);
 
     return [prevPhraseIndex, currentPhraseIndex, nextPhraseIndex];

--- a/webpack/components/ScoreControls.jsx
+++ b/webpack/components/ScoreControls.jsx
@@ -7,16 +7,6 @@ import { convertSecondsToHhmmss } from "../utils";
 
 const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
 
-export const determineCurrentPhrase = (currentTime, phrases) =>
-  currentTime > 0
-    ? phrases.length -
-      (phrases
-        .filter(Boolean)
-        .reverse()
-        .findIndex(phrase => currentTime >= phrase.startTime.value) +
-        1)
-    : 0;
-
 class ScoreControls extends Component {
   constructor(props) {
     super(props);
@@ -56,16 +46,41 @@ class ScoreControls extends Component {
     });
   }
 
-  render() {
-    const currentPhraseIndex = determineCurrentPhrase(
-      this.props.currentTime,
-      this.props.phrases
-    );
+  determinePhraseIndices() {
+    const { currentTime, duration, startTime, phrases } = this.props;
+
+    if (currentTime < startTime) {
+      return [null, null, 0];
+    }
+    // The ugly +1 is here to account for fractions of seconds; not 100%
+    //  satisfactory, but doing it properly would mean rewriting a lot of code.
+    if (currentTime > startTime + duration + 1) {
+      return [phrases.length - 1, null, null];
+    }
+
+    const currentPhraseIndex =
+      phrases.length -
+      (phrases
+        .filter(Boolean)
+        .reverse()
+        .findIndex(phrase => currentTime >= phrase.startTime.value) +
+        1);
+
     const nextPhraseIndex = Math.min(
       currentPhraseIndex + 1,
-      this.props.phrases.length - 1
+      phrases.length - 1
     );
     const prevPhraseIndex = Math.max(currentPhraseIndex - 1, 0);
+
+    return [prevPhraseIndex, currentPhraseIndex, nextPhraseIndex];
+  }
+
+  render() {
+    const [
+      prevPhraseIndex,
+      currentPhraseIndex,
+      nextPhraseIndex
+    ] = this.determinePhraseIndices();
     const remainingTime = convertSecondsToHhmmss(
       clamp(
         this.props.startTime + this.props.duration - this.props.currentTime,
@@ -86,6 +101,7 @@ class ScoreControls extends Component {
           <button
             className="sentence-control__prev"
             onClick={() =>
+              prevPhraseIndex !== null &&
               this.props.updateStartTime(
                 this.props.phrases[prevPhraseIndex].startTime.value
               )
@@ -96,12 +112,15 @@ class ScoreControls extends Component {
           <div className="sentence-control__status">
             <span className="sentence-control__title">Sentence:</span>
             <span className="sentence-control__current">
-              {currentPhraseIndex + 1}/{this.props.phrases.length}
+              {currentPhraseIndex == null ? "--" : currentPhraseIndex + 1}/{
+                this.props.phrases.length
+              }
             </span>
           </div>
           <button
             className="sentence-control__next"
             onClick={() =>
+              nextPhraseIndex !== null &&
               this.props.updateStartTime(
                 this.props.phrases[nextPhraseIndex].startTime.value
               )

--- a/webpack/components/ScoreControls.jsx
+++ b/webpack/components/ScoreControls.jsx
@@ -101,6 +101,10 @@ class ScoreControls extends Component {
         <div className="sentence-control">
           <button
             className="sentence-control__prev"
+            disabled={
+              this.props.currentTime <= this.props.startTime ||
+              prevPhraseIndex === null
+            }
             onClick={() =>
               prevPhraseIndex !== null &&
               this.props.updateStartTime(
@@ -120,6 +124,7 @@ class ScoreControls extends Component {
           </div>
           <button
             className="sentence-control__next"
+            disabled={nextPhraseIndex === null}
             onClick={() =>
               nextPhraseIndex !== null &&
               this.props.updateStartTime(


### PR DESCRIPTION
This PR closes #364, #365, and #391.  Fixes the bugs, and adds some additional desired (/expected) behaviours.

The fixes expose what is arguably a bug in the score -- when the main video slider is out-of-range of the current section "to the left" (i.e., before the shodan section begins), the score shows "No score in this sentence"; when it is out-of-range "to the right" (after the shodan section ends), it shows the last sentence score for the shodan section.  If we continue to allow the main video to be out-of-range in this fashion, we might look at better behaviour on both counts.