### PR TITLE
Pin post-filter scroll to top of container

### DIFF
--- a/src/assets/filters.js
+++ b/src/assets/filters.js
@@ -74,6 +74,10 @@ function attachFilters() {
             elem.style.display = show > 0 ? "inherit" : "none";
           }
         });
+        // Avoid jump scrolling down to last (often invisible) card
+        document
+          .querySelectorAll("a.filters__card")[0]
+          .parentElement.scrollIntoView();
       },
       false
     );


### PR DESCRIPTION
This addresses #390. The logic to show/hide cards in the catalog when filters are checked or unchecked sometimes would cause the cards pane to jump to  the bottom (leaving few if any cards visible), if the user previously had activated that pane by manually scrolling it. This PR avoids such behavior by pinning the post-filter scroll position to the top of the pane.