### PR TITLE
Fix bug with multiple audio cards on same page

### DIFF
--- a/src/_includes/audio-clip.html
+++ b/src/_includes/audio-clip.html
@@ -2,31 +2,24 @@
 {% assign controls_id = include.src | append: "_controls" %}
 
 <li class="mini-cards__element">
-  <audio id="{{ player_id }}">
+  <audio id="{{ player_id }}"
+    onended="
+      document.getElementById('{{ controls_id }}').classList.remove('audio-playing');
+      document.getElementById('{{ controls_id }}').classList.add('audio-player');"
+  >
     <source src="{{ include.src }}" type="audio/mpeg">
     No browser audio support.
   </audio>
-  <div id="{{ controls_id }}" class="audio-label audio-player">{{include.text}}</div>
+  <div id="{{ controls_id }}" class="audio-label audio-player"
+    onclick="
+      if (this.classList.contains('audio-playing')) {
+        this.classList.remove('audio-playing');
+        this.classList.add('audio-player');
+        document.getElementById('{{ player_id }}').pause();
+      } else {
+        this.classList.remove('audio-player');
+        this.classList.add('audio-playing');
+        document.getElementById('{{ player_id }}').play();
+      }"
+  >{{include.text}}</div>
 </li>
-
-<script>
-  var controls = document.getElementById("{{ controls_id }}");
-  var player = document.getElementById("{{ player_id }}");
-
-  player.onended = function() {
-    controls.classList.remove('audio-playing');
-    controls.classList.add('audio-player');
-  }
-
-  controls.onclick = function() {
-    if (controls.classList.contains('audio-playing')) {
-      controls.classList.remove('audio-playing');
-      controls.classList.add('audio-player');
-      player.pause();
-    } else {
-      controls.classList.remove('audio-player');
-      controls.classList.add('audio-playing');
-      player.play();
-    }
-  }
-</script>


### PR DESCRIPTION
The initial audio player card implementation used js variables to keep track of the controls and player elements. These variables would be overwritten with undesired results if the page contained multiple players (because the players are populated via a Liquid template).
This update avoids using js variables. One also could imagine a fix that climbs up and down the local element tree to find the corresponding player and controls, but it's not clear how it would offer any real advantages over just using `getElementById()`.