### PR TITLE
Add svg/path to clickable tags

### DIFF
--- a/webpack/section.jsx
+++ b/webpack/section.jsx
@@ -85,7 +85,7 @@ export default class App extends Component {
   }
 
   handleToggle(event, toggleName) {
-    if (event.target.tagName === "H3") {
+    if (["H3", "path", "svg"].includes(event.target.tagName)) {
       this.setState(prevState => ({
         [toggleName]: !prevState[toggleName]
       }));


### PR DESCRIPTION
This is the simplest fix for #377: just adding "svg" and "path" to the set of tag names that will prompt a toggle when clicked. Previously the only clickable tag type was "H3" -- the text of the accordion section header.
Because the full content of the accordion sections (libretto or shodan map) is included in the component scope, however, unwanted toggles would result if the section contents included other SVGs and the user clicked on them. I have another branch that avoids this potential complication by isolating the clickable header elements in a single div, but it's somewhat more complicated, and it seems unlikely that SVGs will be added to the accordion contents at this late date. 