### PR TITLE
Show section scrubber/playback controls even if there's no score

### DIFF
--- a/webpack/__tests__/__snapshots__/scorecontrols.spec.jsx.snap
+++ b/webpack/__tests__/__snapshots__/scorecontrols.spec.jsx.snap
@@ -69,6 +69,7 @@ exports[`<ScoreControls> renders as expected by default 1`] = `
   >
     <button
       className="score-controls__filters-button"
+      disabled={false}
       onClick={[Function]}
     >
       Filters
@@ -322,6 +323,7 @@ exports[`<ScoreControls> renders as expected by default at the end of the durati
   >
     <button
       className="score-controls__filters-button"
+      disabled={false}
       onClick={[Function]}
     >
       Filters
@@ -2391,6 +2393,7 @@ exports[`<ScoreControls> renders as expected by default with a store 1`] = `
         >
           <button
             className="score-controls__filters-button"
+            disabled={false}
             onClick={[Function]}
           >
             Filters

--- a/webpack/components/ScoreControls.jsx
+++ b/webpack/components/ScoreControls.jsx
@@ -87,9 +87,10 @@ class ScoreControls extends Component {
           <div className="sentence-control__status">
             <span className="sentence-control__title">Sentence:</span>
             <span className="sentence-control__current">
-              {currentPhraseIndex == null ? "--" : currentPhraseIndex + 1}/{
-                this.props.phrases.length
-              }
+              {currentPhraseIndex == null ? "--" : currentPhraseIndex + 1}/{this
+                .props.phrases.length
+                ? this.props.phrases.length
+                : "--"}
             </span>
           </div>
           <button
@@ -119,6 +120,7 @@ class ScoreControls extends Component {
           <button
             className="score-controls__filters-button"
             onClick={() => this.filtersPopup.classList.toggle("hidden")}
+            disabled={!this.props.phrases.length}
           >
             Filters
           </button>

--- a/webpack/section.jsx
+++ b/webpack/section.jsx
@@ -96,25 +96,29 @@ export default class App extends Component {
     const prevSectionURL = this.getSectionURLS()[0];
     const nextSectionURL = this.getSectionURLS()[1];
     const score =
-      this.props.phrases && this.props.phrases.length > 0 ? (
-        [
-          <Score
-            key="score"
-            startTime={this.props.startTime}
-            duration={this.props.duration}
-            phrases={this.props.phrases}
-          />,
-          <ScoreControls
-            key="score-controls"
-            isPrevSentenceOn={false}
-            startTime={this.props.startTime}
-            duration={this.props.duration}
-            phrases={this.props.phrases}
-          />
-        ]
-      ) : (
-        <div className="score score-no-phrases">No score in this section</div>
-      );
+      this.props.phrases && this.props.phrases.length > 0
+        ? [
+            <Score
+              key="score"
+              startTime={this.props.startTime}
+              duration={this.props.duration}
+              phrases={this.props.phrases}
+            />
+          ]
+        : [
+            <div key="score" className="score score-no-phrases">
+              No score in this section
+            </div>
+          ];
+    score.push(
+      <ScoreControls
+        key="score-controls"
+        isPrevSentenceOn={false}
+        startTime={this.props.startTime}
+        duration={this.props.duration}
+        phrases={this.props.phrases}
+      />
+    );
     const toggle = (
       <svg
         xmlns="http://www.w3.org/2000/svg"

--- a/webpack/utils.js
+++ b/webpack/utils.js
@@ -71,6 +71,9 @@ export function determinePhraseIndices({
   startTime,
   phrases
 }) {
+  if (phrases.length == 0) {
+    return [null, null, null];
+  }
   if (currentTime < startTime) {
     return [null, null, 0];
   }

--- a/webpack/utils.js
+++ b/webpack/utils.js
@@ -71,7 +71,7 @@ export function determinePhraseIndices({
   startTime,
   phrases
 }) {
-  if (phrases.length == 0) {
+  if (phrases.length === 0) {
     return [null, null, null];
   }
   if (currentTime < startTime) {


### PR DESCRIPTION
A section is considered to have a "score" if there is any data/metadata in its `phrases` property to display under the video player. This PR enables the section timeline scrubber controls even when `phrases` is empty, as requested in #378. The filters and sentence skip buttons are disabled in this case.
Probably this PR should be rebased after #398 is merged. 