### PR TITLE
Change "Section" to "Shōdan" in L1 and L2

### DIFF
--- a/webpack/__tests__/__snapshots__/intermediatitle.spec.jsx.snap
+++ b/webpack/__tests__/__snapshots__/intermediatitle.spec.jsx.snap
@@ -7,7 +7,7 @@ exports[`<IntermediaTitle> renders as expected 1`] = `
   <div
     className="intermedia__label"
   >
-    Section
+    Shōdan
   </div>
   <div
     className="intermedia__value"

--- a/webpack/__tests__/__snapshots__/play.spec.jsx.snap
+++ b/webpack/__tests__/__snapshots__/play.spec.jsx.snap
@@ -6771,7 +6771,7 @@ exports[`<Play> renders as expected 1`] = `
                       <div
                         className="intermedia__label"
                       >
-                        Section
+                        Shōdan
                       </div>
                       <div
                         className="intermedia__value"

--- a/webpack/__tests__/__snapshots__/sectioncontrols.spec.jsx.snap
+++ b/webpack/__tests__/__snapshots__/sectioncontrols.spec.jsx.snap
@@ -11,7 +11,7 @@ exports[`<SectionControls> renders a disabled button as expected 1`] = `
       className="section-controls__button"
       disabled={true}
     >
-      Previous section
+      Previous Shōdan
     </button>
   </a>
   <a
@@ -21,7 +21,7 @@ exports[`<SectionControls> renders a disabled button as expected 1`] = `
       className="section-controls__button"
       disabled={false}
     >
-      Next Section
+      Next Shōdan
     </button>
   </a>
 </div>
@@ -38,7 +38,7 @@ exports[`<SectionControls> renders as expected by default 1`] = `
       className="section-controls__button"
       disabled={false}
     >
-      Previous section
+      Previous Shōdan
     </button>
   </a>
   <a
@@ -48,7 +48,7 @@ exports[`<SectionControls> renders as expected by default 1`] = `
       className="section-controls__button"
       disabled={false}
     >
-      Next Section
+      Next Shōdan
     </button>
   </a>
 </div>

--- a/webpack/components/IntermediaTitle.jsx
+++ b/webpack/components/IntermediaTitle.jsx
@@ -4,7 +4,7 @@ import PropTypes from "prop-types";
 // May need to capitalize title...
 const IntermediaTitle = props => (
   <div className="intermedia__element intermedia__element--title">
-    <div className="intermedia__label">Section</div>
+    <div className="intermedia__label">Shōdan</div>
     <div className="intermedia__value">
       <a href={props.sectionUrl} title={props.section}>
         <span>{props.section}</span>

--- a/webpack/components/SectionControls.jsx
+++ b/webpack/components/SectionControls.jsx
@@ -8,7 +8,7 @@ const SectionControls = props => (
         className="section-controls__button"
         disabled={props.prevSectionURL === ""}
       >
-        Previous section
+        Previous Shōdan
       </button>
     </a>
     <a href={props.nextSectionURL}>
@@ -16,7 +16,7 @@ const SectionControls = props => (
         className="section-controls__button"
         disabled={props.nextSectionURL === ""}
       >
-        Next Section
+        Next Shōdan
       </button>
     </a>
   </div>

--- a/webpack/section.jsx
+++ b/webpack/section.jsx
@@ -107,7 +107,7 @@ export default class App extends Component {
           ]
         : [
             <div key="score" className="score score-no-phrases">
-              No score in this section
+              No score in this shōdan
             </div>
           ];
     score.push(

--- a/webpack/section.jsx
+++ b/webpack/section.jsx
@@ -188,7 +188,7 @@ export default class App extends Component {
                 onKeyPress={null}
               >
                 <div className="sidebar__collapsable-title sidebar__collapsable-title--map">
-                  <h3>{toggle} Section map</h3>
+                  <h3>{toggle} Shōdan map</h3>
                   <ShodanTimeline
                     mode="url"
                     sections={this.props.sections}


### PR DESCRIPTION
The components affected:
- L1 intermedia table (first row)
- L2 sidebar (Shōdan map) and buttons (Previous/Next Shōdan)