### PR TITLE
Disable full sentence readout, filters button; update snapshots

### DIFF
--- a/src/_sass/components/videoplayer/_score-controls.scss
+++ b/src/_sass/components/videoplayer/_score-controls.scss
@@ -12,7 +12,7 @@ $score-checkbox-height: 1.5rem;
 
 .sentence-control {
   min-width: 11rem;
-  @include flex-container($justify:flex-start);
+  @include flex-container($justify:space-around);
 }
 
 .sentence-control__prev,
@@ -45,18 +45,23 @@ $score-checkbox-height: 1.5rem;
 
 .sentence-control__status {
   @include flex-container($justify:flex-start, $align:baseline);
+
+  &.disabled span {
+    cursor: default;
+    opacity: .4;
+  }
 }
 
 .sentence-control__title {
   font-weight: $fw-regular;
-  font-size: $fs-display-xs;
+  font-size: $fs-display-sm;
   margin-right: 0.25rem;
 }
 
 .sentence-control__current {
   font-weight: $fw-semibold;
   font-size: $fs-display-md;
-  min-width: 3rem;
+  min-width: 2rem;
 }
 
 .channel-toggles,
@@ -108,6 +113,11 @@ $score-checkbox-height: 1.5rem;
 
   &:hover {
     background-color: $beige-light;
+  }
+
+  &:disabled {
+    cursor: default;
+    opacity: .4;
   }
 }
 

--- a/src/_sass/components/videoplayer/_section-controls.scss
+++ b/src/_sass/components/videoplayer/_section-controls.scss
@@ -24,6 +24,6 @@
       background-color: $brown40;
       cursor: default;
     }
-}
+  }
 
 }

--- a/src/_sass/layouts/_page.scss
+++ b/src/_sass/layouts/_page.scss
@@ -131,9 +131,6 @@
       padding: 0.5rem;
     }
   }
-
-  .sidebar-contents__section {
-  }
 }
 
 .text-container {

--- a/webpack/__tests__/__snapshots__/scorecontrols.spec.jsx.snap
+++ b/webpack/__tests__/__snapshots__/scorecontrols.spec.jsx.snap
@@ -17,7 +17,7 @@ exports[`<ScoreControls> renders as expected by default 1`] = `
       />
     </button>
     <div
-      className="sentence-control__status"
+      className="sentence-control__status "
     >
       <span
         className="sentence-control__title"
@@ -271,7 +271,7 @@ exports[`<ScoreControls> renders as expected by default at the end of the durati
       />
     </button>
     <div
-      className="sentence-control__status"
+      className="sentence-control__status "
     >
       <span
         className="sentence-control__title"
@@ -2313,7 +2313,7 @@ exports[`<ScoreControls> renders as expected by default with a store 1`] = `
             />
           </button>
           <div
-            className="sentence-control__status"
+            className="sentence-control__status "
           >
             <span
               className="sentence-control__title"

--- a/webpack/components/ScoreControls.jsx
+++ b/webpack/components/ScoreControls.jsx
@@ -84,7 +84,11 @@ class ScoreControls extends Component {
           >
             <i className="fas fa-step-backward" />
           </button>
-          <div className="sentence-control__status">
+          <div
+            className={`sentence-control__status ${
+              !this.props.phrases.length ? "disabled" : ""
+            }`}
+          >
             <span className="sentence-control__title">Sentence:</span>
             <span className="sentence-control__current">
               {currentPhraseIndex == null ? "--" : currentPhraseIndex + 1}/{this


### PR DESCRIPTION
Disables (sets `opacity=.4`) for "Sentence N/M" readout and filters button when the current shōdan has no score. Some miscellaneous CSS cleanup and adjustments included.