### PR TITLE
Add fa-compass icon for help

### DIFF
--- a/src/_includes/footer.html
+++ b/src/_includes/footer.html
@@ -41,7 +41,7 @@
             <li class="footer__nav-title"><a href="/">Home</a></li>
           </ul>
           <ul class="footer__nav">
-            <li class="footer__nav-title"><a href="/help/">[?] How To</a></li>
+            <li class="footer__nav-title"><a href="/help/">Guide <i class="fas fa-compass"></i></a></li>
           </ul>
           <ul class="footer__nav">
             <li class="footer__nav-title"><a href="/credits">Credits</a></li>

--- a/src/_includes/header-content.html
+++ b/src/_includes/header-content.html
@@ -11,19 +11,15 @@
 
   <nav class="header__nav">
     <ul>
-      <li class="{% if page.menu-active == 'help' or page.menu-active == 'help' %} active{% endif %}">
-        <a class="header__main-link" href="/help/">[?]</a>
-        </li>
-
-        <li class="dropdown-menu{% if page.menu-active == 'intermedia' or page.menu-active == 'intermedia' %} active{% endif %}">
-          <a class="header__main-link dropdown-menu__trigger">Intermedia</a>
-          <ul class="dropdown-menu__list">
-            <li class="dropdown-menu__title"><a href="/about-intermedia/">Intermedia</a></li>
-            <li><a href="/about-intermedia/">Apropos</a></li>
-            <li><a href="/about-intermedia/#intermedia-tools">Tools of Analysis</a></li>
-            <li><a href="/about-intermedia/#noh-as-intermedia">Noh as Intermedia</a></li>
-          </ul>
-        </li>
+      <li class="dropdown-menu{% if page.menu-active == 'intermedia' or page.menu-active == 'intermedia' %} active{% endif %}">
+        <a class="header__main-link dropdown-menu__trigger">Intermedia</a>
+        <ul class="dropdown-menu__list">
+          <li class="dropdown-menu__title"><a href="/about-intermedia/">Intermedia</a></li>
+          <li><a href="/about-intermedia/">Apropos</a></li>
+          <li><a href="/about-intermedia/#intermedia-tools">Tools of Analysis</a></li>
+          <li><a href="/about-intermedia/#noh-as-intermedia">Noh as Intermedia</a></li>
+        </ul>
+      </li>
       <li class="dropdown-menu{% if page.menu-active == 'plays' or page.menu-active == 'plays' %} active{% endif %}">
         <a class="header__main-link dropdown-menu__trigger">Plays</a>
         <ul class="dropdown-menu__list">
@@ -45,6 +41,9 @@
           <li><a href="/staging/">Staging</a></li>
           <li><a href="/form/">Form</a></li>
         </ul>
+      </li>
+      <li class="dropdown-menu{% if page.menu-active == 'help' or page.menu-active == 'help' %} active{% endif %}">
+        <a title="Guide to the site" class="header__main-link" href="/help/"><i class="fas fa-compass"></i></a>
       </li>
     </ul>
   </nav>


### PR DESCRIPTION
Addresses #414. The FontAwesome compass icon appears on the front page wherever the `[?]` placeholder previously was found (in the header and the footer). The header element was moved to the right edge and given the same padding as the other menu items.