### PR TITLE
Use "value" instead of "number" as numberOfPercussion data field

### DIFF
--- a/webpack/components/IntermediaTable.jsx
+++ b/webpack/components/IntermediaTable.jsx
@@ -72,7 +72,7 @@ IntermediaTable.propTypes = {
       }),
       voice: PropTypes.shape({ value: PropTypes.string }),
       text: PropTypes.shape({ value: PropTypes.string }),
-      numberOfPercussion: PropTypes.shape({ number: PropTypes.string }),
+      numberOfPercussion: PropTypes.shape({ value: PropTypes.string }),
       percussion: PropTypes.shape({ value: PropTypes.string }),
       nokhanPresent: PropTypes.shape({
         present: PropTypes.string,


### PR DESCRIPTION
I'm not sure how this change was introduced, but the linter was complaining about it, because the `IntermediaTable.jsx` component render code was using the `value` field of `numberOfPercussion` while the propTypes only listed `number`. The `number` field from the data spreadsheets isn't actually used anywhere in the code, though it's also referenced in the propTypes of `play.jsx`.