### PR TITLE
Tab contents in Level 1 and 2 sidebar scroll to top on tab change

### DIFF
--- a/src/_sass/components/videoplayer/_narrative.scss
+++ b/src/_sass/components/videoplayer/_narrative.scss
@@ -4,7 +4,8 @@
 .narrative {
   flex-grow: 1;
   overflow-y: auto;
-  padding: 2.5rem 1rem 2rem 1rem;
+  padding: 0 1rem 0 0;
+  margin: 2rem 0 0 1rem;
 
   .collapsible {
     align-items: center;

--- a/webpack/__tests__/__snapshots__/play.spec.jsx.snap
+++ b/webpack/__tests__/__snapshots__/play.spec.jsx.snap
@@ -1420,11 +1420,13 @@ exports[`<Play> renders as expected 1`] = `
                   <Tabs
                     defaultFocus={false}
                     defaultIndex={null}
+                    domRef={[Function]}
                     forceRenderTabPanel={false}
                     selectedIndex={null}
                   >
                     <UncontrolledTabs
                       className="react-tabs"
+                      domRef={[Function]}
                       focus={false}
                       forceRenderTabPanel={false}
                       onSelect={[Function]}
@@ -1519,7 +1521,14 @@ exports[`<Play> renders as expected 1`] = `
                           className="react-tabs__tab-panel"
                           forceRender={false}
                           id="react-tabs-1"
-                          key=".1:$0"
+                          key=".1:$<section id=0\\"intro\\" title=0\\"Introduction\\" class=0\\"tabbed-narrative\\">
+  <h2>Title</h2>
+  <p>Lorem ipsum dolor sit amet, <time datetime=0\\"00=200=210.000\\" title=0\\"00=210=298.987\\">consectetur</time> adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.</p>
+  <p>Lorem ipsum dolor sit amet, <time datetime=0\\"00=200=220\\" title=0\\"00=211=298.987\\">consectetur</time> adipisicing elit. Excepteur sint occaecat cupidatat non sproident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+  <h3>Subtitle</h3>
+  <p>Lorem ipsum dolor sit amet, <time datetime=0\\"00=200=210.000\\" title=0\\"00=210=298.987\\">consectetur</time> adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.</p>
+  <p>Lorem ipsum dolor sit amet, <time datetime=0\\"00=200=220\\" title=0\\"00=211=298.987\\">consectetur</time> adipisicing elit. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+</section>"
                           selected={true}
                           selectedClassName="react-tabs__tab-panel--selected"
                           tabId="react-tabs-0"
@@ -1773,7 +1782,10 @@ exports[`<Play> renders as expected 1`] = `
                           className="react-tabs__tab-panel"
                           forceRender={false}
                           id="react-tabs-3"
-                          key=".1:$1"
+                          key=".1:$<section id=0\\"part1\\" title=0\\"Part I\\" class=0\\"tabbed-narrative\\">
+  <h2>Part I</h2>
+  <p>Lorem ipsum dolor sit amet, <time datetime=0\\"00=200=220\\" title=0\\"00=211=298.987\\">consectetur</time> adipisicing elit. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+</section>"
                           selected={false}
                           selectedClassName="react-tabs__tab-panel--selected"
                           tabId="react-tabs-2"
@@ -1789,7 +1801,10 @@ exports[`<Play> renders as expected 1`] = `
                           className="react-tabs__tab-panel"
                           forceRender={false}
                           id="react-tabs-5"
-                          key=".1:$2"
+                          key=".1:$<section id=0\\"part2\\" title=0\\"Part II\\" class=0\\"tabbed-narrative\\">
+  <h2>Part II</h2>
+  <p>Lorem ipsum dolor sit amet, <time datetime=0\\"00=200=230.303\\" title=0\\"00=212=298.987\\">consectetur</time> adipisicing elit. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</p>
+</section>"
                           selected={false}
                           selectedClassName="react-tabs__tab-panel--selected"
                           tabId="react-tabs-4"

--- a/webpack/__tests__/__snapshots__/tabbednarrative.spec.jsx.snap
+++ b/webpack/__tests__/__snapshots__/tabbednarrative.spec.jsx.snap
@@ -4,6 +4,7 @@ exports[`<TabbedNarrative> renders as expected 1`] = `
 <Tabs
   defaultFocus={false}
   defaultIndex={null}
+  domRef={[Function]}
   forceRenderTabPanel={false}
   selectedIndex={null}
 >

--- a/webpack/__tests__/tabbednarrative.spec.jsx
+++ b/webpack/__tests__/tabbednarrative.spec.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { shallow } from "enzyme";
+import { shallow, mount } from "enzyme";
 import TabbedNarrative from "../components/TabbedNarrative";
 
 describe("<TabbedNarrative>", () => {
@@ -9,5 +9,20 @@ describe("<TabbedNarrative>", () => {
   it("renders as expected", () => {
     const component = shallow(<TabbedNarrative narrative={tabbedAnalysis} />);
     expect(component).toMatchSnapshot();
+  });
+
+  it("ref handler runs with tabs ref", () => {
+    const component = mount(
+      <div className="narrative" role="presentation">
+        <TabbedNarrative narrative={tabbedAnalysis} />
+      </div>
+    );
+    const tabN = component.find("TabbedNarrative");
+    tabN.instance().handleDomRef(tabN.getDOMNode());
+  });
+
+  it("ref handler runs with null input", () => {
+    const component = shallow(<TabbedNarrative narrative={tabbedAnalysis} />);
+    component.instance().handleDomRef(null);
   });
 });

--- a/webpack/components/TabbedNarrative.jsx
+++ b/webpack/components/TabbedNarrative.jsx
@@ -1,5 +1,3 @@
-/* eslint-disable react/no-array-index-key */
-
 import React from "react";
 import PropTypes from "prop-types";
 import { Markup } from "interweave";
@@ -9,24 +7,32 @@ class TabbedNarrative extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      narrative: props.narrative
+      chunks: null,
+      titles: null
+    };
+
+    /* This function is triggered on all tab changes, as well as some other
+    * events. It is used to scroll the visible tab panel to the top upon
+    * activation, if necessary. */
+    this.handleDomRef = tabsRef => {
+      if (tabsRef !== null) {
+        const { parentElement } = tabsRef;
+        parentElement.scrollTop = 0;
+      }
     };
   }
 
   componentWillMount() {
-    this.parseNarrative();
+    const [chunks, titles] = this.parseNarrative();
+    this.setState({ chunks, titles });
   }
 
   parseNarrative() {
     const nar = document.createElement("div");
-    nar.innerHTML = this.state.narrative;
+    nar.innerHTML = this.props.narrative;
     const sections = nar.querySelectorAll("section");
     const chunks = Array.from(sections).map(elt => elt.outerHTML);
-    return chunks;
-  }
 
-  panelTitles() {
-    const chunks = this.parseNarrative();
     const re = /title=['"][\w\s]+['"]/;
     const titles = [];
     for (let i = 0; i < chunks.length; i += 1) {
@@ -35,22 +41,21 @@ class TabbedNarrative extends React.Component {
       const title = pieces[1].slice(1, -1);
       titles.push(title);
     }
-    return titles;
+
+    return [chunks, titles];
   }
 
   render() {
-    const chunks = this.parseNarrative();
-    const titles = this.panelTitles();
-    const narrativeTabList = titles.map(title => (
+    const narrativeTabList = this.state.titles.map(title => (
       <Tab key={title}>{title}</Tab>
     ));
-    const narrativeTabs = chunks.map((chunk, index) => (
-      <TabPanel key={index}>
+    const narrativeTabs = this.state.chunks.map(chunk => (
+      <TabPanel key={chunk}>
         <Markup content={chunk} />
       </TabPanel>
     ));
     return (
-      <Tabs>
+      <Tabs domRef={this.handleDomRef}>
         <TabList>{narrativeTabList}</TabList>
         {narrativeTabs}
       </Tabs>
@@ -59,11 +64,7 @@ class TabbedNarrative extends React.Component {
 }
 
 TabbedNarrative.propTypes = {
-  narrative: PropTypes.string
-};
-
-TabbedNarrative.defaultProps = {
-  narrative: ""
+  narrative: PropTypes.string.isRequired
 };
 
 export default TabbedNarrative;


### PR DESCRIPTION
Fixes #374. The bug was largely a result of `react-tabs` having no official support for sticky tab headers. The Tabs component does however provide a function hook with access to its root DOM node on every update, which makes it pretty easy to scroll the active tab panel back to the top.  
PR also implements some minor styling improvements and the all important test coverage.