### PR TITLE
Set max-width on row style

### DIFF
--- a/src/_sass/commons/_grid.scss
+++ b/src/_sass/commons/_grid.scss
@@ -38,6 +38,7 @@ $grid-gutter: 1rem;
   flex-shrink: 1;
   flex-wrap: wrap;
   margin: 0 -#{$grid-gutter};
+  max-width: 100%;
 }
 
 .row--center-x {


### PR DESCRIPTION
This fixes a problem that occurs on L0 pages with a row of large cards at the top, e.g., `/about-movement/` and `/text/` where the width of the top cards row pushes past the rest of the page, producing an annoying horizontal scroll bar.