### PR TITLE
Hide main video timeline scrubber on Level 2

### DIFF
--- a/src/_sass/components/videoplayer/_main-player.scss
+++ b/src/_sass/components/videoplayer/_main-player.scss
@@ -1,0 +1,7 @@
+
+// Note: this (obviously) only works with webkit-based browsers.
+//  At present, there is no solution for FF or Edge that replicates
+//  this behaviour.
+#section video::-webkit-media-controls-timeline {
+  display: none;
+}

--- a/src/assets/main.scss
+++ b/src/assets/main.scss
@@ -31,5 +31,6 @@
 @import "components/videoplayer/score";
 @import "components/videoplayer/section-controls";
 @import "components/videoplayer/timeline";
+@import "components/videoplayer/main-player";
 @import "components/styleguide-colors";
 @import "components/styleguide-typography";


### PR DESCRIPTION
Note: this (obviously) only works with webkit-based browsers.  At present, there is no solution for FF or Edge that replicates this behaviour.

Closes #434 and, I think, #318.