### PR TITLE
L1 2 tab title remove

### DIFF
--- a/webpack/__tests__/__snapshots__/play.spec.jsx.snap
+++ b/webpack/__tests__/__snapshots__/play.spec.jsx.snap
@@ -1521,7 +1521,7 @@ exports[`<Play> renders as expected 1`] = `
                           className="react-tabs__tab-panel"
                           forceRender={false}
                           id="react-tabs-1"
-                          key=".1:$<section id=0\\"intro\\" title=0\\"Introduction\\" class=0\\"tabbed-narrative\\">
+                          key=".1:$<section id=0\\"intro\\"  class=0\\"tabbed-narrative\\">
   <h2>Title</h2>
   <p>Lorem ipsum dolor sit amet, <time datetime=0\\"00=200=210.000\\" title=0\\"00=210=298.987\\">consectetur</time> adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.</p>
   <p>Lorem ipsum dolor sit amet, <time datetime=0\\"00=200=220\\" title=0\\"00=211=298.987\\">consectetur</time> adipisicing elit. Excepteur sint occaecat cupidatat non sproident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
@@ -1540,7 +1540,7 @@ exports[`<Play> renders as expected 1`] = `
                             role="tabpanel"
                           >
                             <Markup
-                              content="<section id=\\"intro\\" title=\\"Introduction\\" class=\\"tabbed-narrative\\">
+                              content="<section id=\\"intro\\"  class=\\"tabbed-narrative\\">
   <h2>Title</h2>
   <p>Lorem ipsum dolor sit amet, <time datetime=\\"00:00:10.000\\" title=\\"00:10:98.987\\">consectetur</time> adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.</p>
   <p>Lorem ipsum dolor sit amet, <time datetime=\\"00:00:20\\" title=\\"00:11:98.987\\">consectetur</time> adipisicing elit. Excepteur sint occaecat cupidatat non sproident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
@@ -1571,7 +1571,6 @@ exports[`<Play> renders as expected 1`] = `
                                       Object {
                                         "className": "tabbed-narrative",
                                         "id": "intro",
-                                        "title": "Introduction",
                                       }
                                     }
                                     className=""
@@ -1583,7 +1582,6 @@ exports[`<Play> renders as expected 1`] = `
                                     <section
                                       className="interweave tabbed-narrative"
                                       id="intro"
-                                      title="Introduction"
                                     >
                                       
   
@@ -1782,7 +1780,7 @@ exports[`<Play> renders as expected 1`] = `
                           className="react-tabs__tab-panel"
                           forceRender={false}
                           id="react-tabs-3"
-                          key=".1:$<section id=0\\"part1\\" title=0\\"Part I\\" class=0\\"tabbed-narrative\\">
+                          key=".1:$<section id=0\\"part1\\"  class=0\\"tabbed-narrative\\">
   <h2>Part I</h2>
   <p>Lorem ipsum dolor sit amet, <time datetime=0\\"00=200=220\\" title=0\\"00=211=298.987\\">consectetur</time> adipisicing elit. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
 </section>"
@@ -1801,7 +1799,7 @@ exports[`<Play> renders as expected 1`] = `
                           className="react-tabs__tab-panel"
                           forceRender={false}
                           id="react-tabs-5"
-                          key=".1:$<section id=0\\"part2\\" title=0\\"Part II\\" class=0\\"tabbed-narrative\\">
+                          key=".1:$<section id=0\\"part2\\"  class=0\\"tabbed-narrative\\">
   <h2>Part II</h2>
   <p>Lorem ipsum dolor sit amet, <time datetime=0\\"00=200=230.303\\" title=0\\"00=212=298.987\\">consectetur</time> adipisicing elit. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</p>
 </section>"

--- a/webpack/components/TabbedNarrative.jsx
+++ b/webpack/components/TabbedNarrative.jsx
@@ -39,7 +39,7 @@ class TabbedNarrative extends React.Component {
       const titleString = re.exec(chunks[i]);
       const pieces = titleString[0].split("=");
       const title = pieces[1].slice(1, -1);
-      chunks[i] = chunks[i].replace('title="' + title + '"', "");
+      chunks[i] = chunks[i].replace(`title="${title}"`, "");
       titles.push(title);
     }
     return [chunks, titles];

--- a/webpack/components/TabbedNarrative.jsx
+++ b/webpack/components/TabbedNarrative.jsx
@@ -39,9 +39,9 @@ class TabbedNarrative extends React.Component {
       const titleString = re.exec(chunks[i]);
       const pieces = titleString[0].split("=");
       const title = pieces[1].slice(1, -1);
+      chunks[i] = chunks[i].replace('title="' + title + '"', "");
       titles.push(title);
     }
-
     return [chunks, titles];
   }
 


### PR DESCRIPTION
Addresses #430. The contents of the L1 and L2 tabbed sidebars are loaded in from "narrative" HTML files, and the `title=` attribute of each `<section>` in the HTML file is used as the label of the section's tab. The section's HTML is then dropped wholesale into the tab contents; if the `title=` attribute is not cleared, it appears as a tooltip whenever the tab is hovered.