### PR TITLE
Bring sticky sidebars down a bit

### DIFF
--- a/src/_sass/components/_filters.scss
+++ b/src/_sass/components/_filters.scss
@@ -16,9 +16,9 @@
   flex-shrink: 0;
   padding-right: 1rem;
   position: sticky;
-  top: 0;
+  top: 50px;
   overflow-y: auto;
-  max-height: 100vh;
+  max-height: calc(100vh - 50px - 10px); // the extra 10px is to allow a little space at the bottom
 
   ul {
     margin-bottom: 2rem;

--- a/src/_sass/layouts/_page.scss
+++ b/src/_sass/layouts/_page.scss
@@ -121,10 +121,9 @@
     margin-top: 4rem;
     padding: 0.5rem;
     position: sticky;
-    position: -webkit-sticky;
-    top: 0;
+    top: 50px;
     overflow-y: auto;
-    max-height: 100vh;
+    max-height: calc(100vh - 50px - 10px); // the extra 10px is to allow a little space at the bottom
 
     h4 {
       color: $brown;


### PR DESCRIPTION
...so that they're not obscured by the slide-down menu when scrolling.  A nice long example for testing the jump menus can be found at `/music/voices/`, and for filters see `/catalog-of-shodan/` of course, but also the Catalog of Kata at `/movement/`.

Closes #438.