### PR TITLE
Scroll to filters__container div on filter change

### DIFF
--- a/src/assets/filters.js
+++ b/src/assets/filters.js
@@ -74,10 +74,9 @@ function attachFilters() {
             elem.style.display = show > 0 ? "inherit" : "none";
           }
         });
-        // Avoid jump scrolling down to last (often invisible) card
-        document
-          .querySelectorAll("a.filters__card")[0]
-          .parentElement.scrollIntoView();
+        // Avoid jump scrolling down to last (often invisible) card, while
+        // ensuring the top row of cards isn't obscured by the sticky header
+        document.querySelector("div.filters__container").scrollIntoView();
       },
       false
     );


### PR DESCRIPTION
As noted in the comment to #390,  jump-scrolling to the top level of cards when a filter is selected on one of the catalog pages (`/movement/`, `/catalog-of-shodan/`) can trigger the sticky secondary header to slide out, which then obscures the top level of cards. This addresses the problem by jump-scrolling to an element that is closer to the top of the page.