### PR TITLE
Add a little horizontal padding around card text

### DIFF
--- a/src/_sass/components/website/card-menu.scss
+++ b/src/_sass/components/website/card-menu.scss
@@ -16,6 +16,7 @@ $card-menu-large-element-size: 8.75rem;
     
     span {
       @include text(xs);
+      padding: 0 .2rem;
     }
   }
   


### PR DESCRIPTION
This triggers a line break between words. Otherwise, the text of cards like "Shimai Dances" on `/shimai-dances/` stay one one line and run right up to the edge of the card.