### PR TITLE
Allow popout window to self-maximise with `fullscreen` param passed

### DIFF
--- a/src/_layouts/popout.html
+++ b/src/_layouts/popout.html
@@ -114,6 +114,12 @@
     let timeFrom, timeTo;
     let mediaFragUrl = plays[playName].videoUrl;
     const urlFragParams = parseUrlFragment();
+
+    if (Object.keys(urlFragParams).includes("fullscreen")) {
+      window.moveTo(0,0);
+      window.resizeTo(screen.availWidth, screen.availHeight);
+    }
+
     if (Object.keys(urlFragParams).includes("t")) {
       [timeFrom, timeTo] = urlFragParams.t.split(',');
       timeFrom = validateTimestamp(timeFrom) || "";


### PR DESCRIPTION
Closes #431.  It's not possible for a window or a video element to make itself fullscreen -- the browser APIs require that this action is initiated by a user (i.e. by clicking a button) -- but it can "maximize" itself by expanding to the maximum available height and width, and this has a very similar effect.

Notes:
1. The third parameter to `window.open` is still required -- in its absence, browsers will open the video fullscreen in a new tab.  This could be considered a feature (`autoplay` and `autoclose` will continue to work).
2. There is a bug which (I think) means this won't work properly in Edge?[1]

Suggested use `window.open('/popout/hashitomi/#t=01:30,1:38&autoplay&autoclose&fullscreen', 'new', 'centerscreen');`.

Hopefully this works just as nicely on Macs :)

[1] https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/7205972/