### PR TITLE
Remove alphabetical sort for filter/catalog entities

### DIFF
--- a/src/_includes/filters.html
+++ b/src/_includes/filters.html
@@ -6,7 +6,7 @@
           <h3 class="filters__title">Filter by {{ filter.by }}</h3>
           <ul>
             {% assign last = "" %}
-            {% assign values = filter.values | sort %}
+            {% assign values = filter.values %}
             {% for value in values %}
               {% if last != "" and value.size != 1 and value.first != last %}
                   </ul>
@@ -48,7 +48,7 @@
       </div>
       <div class="filters__card-container">
         {% for card in include.catalog.cards %}
-          {% assign pills = card.pills | uniq | sort | join: ',' %}
+          {% assign pills = card.pills | uniq | join: ',' %}
           {% include filter-card.html
             title=card.name
             slug=card.slug


### PR DESCRIPTION
These changes address a bit more than the alphabetical sorting of the tag pills in the catalog of Shōdan as mentioned in #435, but I believe they provide the behavior for both catalogs -- including also the Catalog of Kata (Movement) -- that the PIs prefer. With the removal of the `sort` directives, none of the filters, cards, or tag pills are ordered alphabetically; rather their orders are determined entirely by the sequencing of the rows and columns in the "Categorization of Shōdan and Movement" data spreadsheet from which their labels are derived. Specifically:

Catalog of Shōdan:
- Content and sequencing of the sidebar filters and tag pills is determined by the top row of column headers of the "Shodan By act" and "Shodan By type" sheets, in that order
- Order of the catalog cards is determined by the "Names" column of the "Shodan by type" sheet

Catalog of Kata:
- Content and sequencing of the sidebar filters and tag pills is determined by the top row of column headers of the "Movement - Formal" and "Movement - Decorative" sheets, in that order
- Order of the catalog cards is determined by the "Names" column of the "Movement - Formal" and "Movement - Decorative" sheets, in that order
