### PR TITLE
Keep tooltip arrows from leaving the body behind

### DIFF
--- a/src/_sass/commons/_mixins.scss
+++ b/src/_sass/commons/_mixins.scss
@@ -65,14 +65,10 @@
 @mixin tooltip-center {
   @include tooltip();
 
-  &::before {
-    border-radius: 0.125rem;
-  }
-
   &::before,
   &::after {
     left: 50%;
-    transform: translateX(-50%);
+    transform: translateX(-0.5rem);
   }
 }
 


### PR DESCRIPTION
A proposed fix for #454. On reasonable screen sizes, the arrows now stay attached to the tooltip bodies, and more or less point to the element that's being highlighted. A downside is that the arrows tend to stick out from the left side of the tooltip more often now, which can look kind of weird. Ideas for more sophisticated fixes would be welcome. In any case, the `z-index` of the arrow should be set; otherwise it can be obscured by the section boxes.