### PR TITLE
Force scrollbars on narrative

### DIFF
--- a/src/_sass/components/videoplayer/_narrative.scss
+++ b/src/_sass/components/videoplayer/_narrative.scss
@@ -3,7 +3,7 @@
 
 .narrative {
   flex-grow: 1;
-  overflow-y: auto;
+  overflow-y: scroll;
   padding: 0 1rem 0 0;
   margin: 2rem 0 0 1rem;
 


### PR DESCRIPTION
This makes no difference on systems with overlay scrollbars (e.g. Macs), but fixes #332 on those which don't (most Windows and Linux systems).