### PR TITLE
Tighten spacing in all static page headers, not just catalogs

### DIFF
--- a/src/_sass/components/_filters.scss
+++ b/src/_sass/components/_filters.scss
@@ -2,8 +2,8 @@
   background-color: $beige-light;
   border-bottom: $border;
   border-top: $border;
-  margin: 4rem 0;
-  padding: 4rem 0;
+  margin: 2rem 0;
+  padding: 1rem 0;
 }
 
 .filters__content {

--- a/src/_sass/components/website/card-menu.scss
+++ b/src/_sass/components/website/card-menu.scss
@@ -51,7 +51,7 @@ $card-menu-large-element-size: 8.75rem;
 }
 
 .card-menu--large {
-  padding: 3.5rem 0 3rem 0;
+  padding: 2rem 0 1rem 0;
 
   .card-menu__element {
     height: $card-menu-large-element-size;

--- a/src/_sass/layouts/_layout-commons.scss
+++ b/src/_sass/layouts/_layout-commons.scss
@@ -9,8 +9,8 @@
 
 .text-container {
   @extend .wrapper;
-  margin-bottom: 4rem;
-  margin-top: 4rem;
+  margin-bottom: 2rem;
+  margin-top: 1rem;
 }
 
 .tabs-container {

--- a/src/_sass/layouts/_page.scss
+++ b/src/_sass/layouts/_page.scss
@@ -118,7 +118,7 @@
     flex-basis: 14rem;
     flex-shrink: 0;
     margin-right: 2rem;
-    margin-top: 4rem;
+    margin-top: 2rem;
     padding: 0.5rem;
     position: sticky;
     top: 50px;

--- a/src/about-movement.md
+++ b/src/about-movement.md
@@ -7,63 +7,129 @@ permalink: /about-movement/
 ---
 
 {% include second-menu-elements.html %}
-{% include menu-dances-large.html %}
 
 <main class="page-content">
-
-  <div class="wrapper sidebar-contents">
-    <aside class="sidebar-contents__table">
-      {% include menu-movement.html %}
-    </aside>
-    <section class="sidebar-contents__section">
   <div class="text-container">
-    <h2 class="collapsible collapsible-closed" id="Intro">Movement</h2>
+    {% include menu-dances-large.html %}
 
-  <p>Despite its apparent minimalism the movement in Noh is vital, sophisticated and performed with greatest precision. It serves structural, easthetic and narrative functions. It co-creates <em>kurai</em>, the overarching essential expressive quality of the play.</p>
+    <div class="wrapper sidebar-contents">
+      <aside class="sidebar-contents__table">
+        {% include menu-movement.html %}
+      </aside>
+      <section class="sidebar-contents__section">
 
-  <p>It's structural role consists of guiding viewers through the form of the plays by using predictable devices and stage positions. For example, one can expect that the play will start with the waki entering and walking to Square 1 to present his introduction, and then, continuing to a standard waki position at Square 5. Or, during the instrumental dance, the viewers can recognize among others the prescribed progression of sections that are differentiated by the fan being first closed, then open, then held above the head. The large scale organization of stage movement creates a familiar frame. Sometimes, it provides a basis for poingnant expressive exceptions.</p>
+        <div class="text-container">
+          <h2 class="collapsible collapsible-closed" id="Intro">Movement</h2>
 
-  <p>On the smaller scale of time, Noh abounds in abstract movement patterns that are equally familiar to the viewers. Using them in different roles allows actors to add unique aesthetic beauty and depth to performed characters by imbuing the movement with subtle expressive qualities. The abstract nature of the patterns in the instrumental dance in particular allows for evocation and profound contemplation of the spirit in its timeless essence.</p>
+          <p>Despite its apparent minimalism the movement in Noh is vital, sophisticated and performed with greatest
+            precision. It serves structural, easthetic and narrative functions. It co-creates <em>kurai</em>, the
+            overarching essential expressive quality of the play.</p>
 
-  <p>When movement is done in direct reference to narrative it is often very sparse. It uses mimetic motives that symbolize rather than literally depict. As such it calls on the imagination of the viewer and by doing so it deepens their engagement with the play, its narrative and the protagonist.</p>
+          <p>It's structural role consists of guiding viewers through the form of the plays by using predictable devices
+            and stage positions. For example, one can expect that the play will start with the waki entering and walking
+            to Square 1 to present his introduction, and then, continuing to a standard waki position at Square 5. Or,
+            during the instrumental dance, the viewers can recognize among others the prescribed progression of sections
+            that are differentiated by the fan being first closed, then open, then held above the head. The large scale
+            organization of stage movement creates a familiar frame. Sometimes, it provides a basis for poingnant
+            expressive exceptions.</p>
 
-<h3 id="Kata">Kata</h3>
-  <p>The movements of actors in Noh are choreographed using an extensive vocabulary of basic patterns called <em>kata</em>. The patterns can be classified into two categories: formal and mimetic. They are sequenced to create more extended stage motions and dances. Our classification and English translation of <em>kata</em> names are based on the work of Monica Bethe and Karen Brazell. (<em>Dance in the Noh Theater</em>, Volumes 1, 2, and 3 published by Cornell University under the Cornell East Asia Series, number 29.) The core elements of all noh movement are the basic posture (<a href="/movement/standing/" target="_blank"><em>kamae</em></a>) that serves as the start and end of all movement and a sliding walk (<a href="/movement/forward/" target="_blank"><em>hakobi</em></a>) that provides the essential flow. </p>
+          <p>On the smaller scale of time, Noh abounds in abstract movement patterns that are equally familiar to the
+            viewers. Using them in different roles allows actors to add unique aesthetic beauty and depth to performed
+            characters by imbuing the movement with subtle expressive qualities. The abstract nature of the patterns in
+            the instrumental dance in particular allows for evocation and profound contemplation of the spirit in its
+            timeless essence.</p>
 
-<h4 id="Formal">Formal kata</h4>
-<p>Ubiquitous and essential, they can appear at any time in the play and anywhere on the stage. Some are performed only at specific times and places serving as markers that help create structure. They can involve wholistic coordination between feet and arms. Some have variants performed with either closed or open fan. They recur throughout the play but are predominant early on and during instrumental dances (<em>mai</em>).</p>
+          <p>When movement is done in direct reference to narrative it is often very sparse. It uses mimetic motives
+            that symbolize rather than literally depict. As such it calls on the imagination of the viewer and by doing
+            so it deepens their engagement with the play, its narrative and the protagonist.</p>
 
-<h4 id="Mimetic">Mimetic kata</h4>
-<p>They serve to add depth to the narrative rather than establish structure. Commonly used mimetically to illustrate meaning of sung text, they are often focused on one body part. They become more frequent as the play progresses and are normally found in such narrative shōdan as <em>kuse</em> and <em>kiri</em>.</p>
-<h3></h3>
-<p>For more information and video examples of kata please refer to the <a href="/movement/" target="_blank">Catalog of Kata</a>. The recordings feature KONGŌ Tatsunori.</p>
+          <h3 id="Kata">Kata</h3>
+          <p>The movements of actors in Noh are choreographed using an extensive vocabulary of basic patterns called
+            <em>kata</em>. The patterns can be classified into two categories: formal and mimetic. They are sequenced to
+            create more extended stage motions and dances. Our classification and English translation of <em>kata</em>
+            names are based on the work of Monica Bethe and Karen Brazell. (<em>Dance in the Noh Theater</em>, Volumes
+            1, 2, and 3 published by Cornell University under the Cornell East Asia Series, number 29.) The core
+            elements of all noh movement are the basic posture (<a href="/movement/standing/"
+              target="_blank"><em>kamae</em></a>) that serves as the start and end of all movement and a sliding walk
+            (<a href="/movement/forward/" target="_blank"><em>hakobi</em></a>) that provides the essential flow. </p>
 
-<h3 id="Modes">Modes of Movement</h3>
-<p>In his early theoretical work Zeami has defined three basic modes of movement:<br>
-Aged Mode (<em>rōtai</em>): for the embodiment of old men, tradition and the divine.<br>
-Feminine Mode (<em>nyotai</em>): suggesting sensitivity to beauty and emotion.<br>
-Martial Mode (<em>guntai</em>): representing supernatural, demonic quality as well as assertive masculinity.</p>
+          <h4 id="Formal">Formal kata</h4>
+          <p>Ubiquitous and essential, they can appear at any time in the play and anywhere on the stage. Some are
+            performed only at specific times and places serving as markers that help create structure. They can involve
+            wholistic coordination between feet and arms. Some have variants performed with either closed or open fan.
+            They recur throughout the play but are predominant early on and during instrumental dances (<em>mai</em>).
+          </p>
 
-<p>These conventions however have expanded during his time and further evolved with the growing repertoire of plays. In contemporary performance one can find fluidity of attributes even within a single play. They can be dictated by the character of a scene or by protagonist's feelings within an evolving narrative.</p>
+          <h4 id="Mimetic">Mimetic kata</h4>
+          <p>They serve to add depth to the narrative rather than establish structure. Commonly used mimetically to
+            illustrate meaning of sung text, they are often focused on one body part with a unique stipulation ex. if
+            the fan is closed or open. They become more frequent as the play progresses and are normally found in such
+            narrative shōdan as <em>kuse</em> and <em>kiri</em>.</p>
+          <h3></h3>
+          <p>For more information and video examples of kata please refer to the <a href="/movement/"
+              target="_blank">Catalog of Kata</a>. The recordings feature KONGŌ Tatsunori.</p>
 
-<p> Conventional dichotomy of feminine and martial modes related to Zeami's categorization is presented on this website to illustrate the spectrum of possibilities. Most generally <em>kata</em> performed in feminine mode are characterized by a close position of the feet, round gesture, slower tempo and a fluid rhythm, whereas <em>kata</em> performed in martial mode have feet positioned further apart, more angular motion, faster tempo and sudden rhythms. For sake of comparison, several <em>kata</em>  included in the Catalog of Kata are presented both in feminine and martial modes. It is important to remember that these contrasting modes can be used by the same character. For instance, a deceased soldier dances in a style with features of the feminine mode, but switches to more martial style when depicting the battle that led to his death.</p>
+          <h3 id="Modes">Modes of Movement</h3>
+          <p>Zeami (c.1363 - c.1443) in his theoretical work has defined three basic modes of movement:<br>
+            Aged Mode (<em>rōtai</em>): embodiment of tradition and the divine.<br>
+            Feminine Mode (<em>nyotai</em>): suggesting sensitivity to beauty and emotion.<br>
+            Martial Mode (<em>guntai</em>): representing supernatural, demonic quality as well as assertive masculinity.
+          </p>
+
+          <p>Yet, the modes are not strictly associated with gender or even specific characters. For instance, in the
+            same play a deceased soldier dances in the feminine mode over melodic and lyrical chanting, but switches to
+            the martial mode when depicting the battle that led to his death.</p>
+          <p>
+            Most generally <em>kata</em> performed in feminine mode are characterized by a close position of the feet,
+            round gesture, slower tempo and a fluid rhythm, whereas <em>kata</em> performed in martial mode have feet
+            positioned further apart, more angular motion, faster tempo and sudden rhythms. For sake of comparison,
+            several <em>kata</em> included in the Catalog of Kata are presented both in feminine and martial modes. </p>
 
 
-<h3 id="Dances">Dances</h3>
-  <p>All movement in Noh is highly formalized and due to its unique aesthetic bares resemblance to dance. In Noh tradition though, there is a special term for dance <em>mai</em> that refers to the central shōdan, typically in the second half of the play, where the movement of the shite is formal and the accompaniment is purely instrumental. These are considered the highlights of the plays. In some plays, all of the performance until then may be seen as the preparation for this special expressive climax when words cease and we get to contemplate the protagonist's nature, essential emotion or state of mind expressed through dance and music only.</p>
+          <h3 id="Dances">Dances</h3>
+          <p>All movement in Noh is highly formalized and due to its unique aesthetic bares resemblance to dance. In Noh
+            tradition though, there is a special term for dance <em>mai</em> that refers to the central shōdan,
+            typically in the second half of the play, where the movement of the shite is formal and the accompaniment is
+            purely instrumental. These are considered the highlights of the plays. In some plays, all of the performance
+            until then may be seen as the preparation for this special expressive climax when words cease and we get to
+            contemplate the protagonist's nature, essential emotion or state of mind expressed through dance and music
+            only.</p>
 
-  <p>There are two kinds of <em>mai</em>: <em>mai</em> proper and <em>hataraki</em>. Both share a basic structure in terms of course of walking. They typically start upstage, move forward, then to the stage-right corner and after circling one or more times return to where they started. Depending on the character of the protagonist either can be slow or fast, the gestures could be more sharp or fluid, and the relationship to the beat strict or flexible. The difference between the two is mostly in the longer duration and larger number of subsections in <em>mai</em> than in <em>hataraki</em>.  The former is normally more of a stand-alone scene, while the latter, functions as a brief underlining of the moment's mood, emotional coloring or dramatic action. <em>Hataraki</em> can be composed of passages that enact a narrative in the play's present like exorcisms or fight scenes. <em>Jonomai</em> from Hashitomi is an example of <em>mai</em>, while <em>maibataraki</em>, represents a <em>hataraki</em></p>
-<H3 id="Shimai">Shimai and Maibayashi</H3>
-<p>Besides dance in the context of a Noh play, there are two other forms of dance. Dance-to-text <em>shōdan</em>,  such as <em>kuse</em> and <em>kiri</em>, can be performed independently from a play. This form of dance called <em>shimai</em> includes a jiutai usually composed of four members, but no <em>hayashi</em>.<br>
-Instrumental dances can also be performed independently from a play. This form of dance called <em>maibayashi</em> includes a <em>hayashi</em> and a jiutai with a membership that can vary between three and eight singers.</p>
+          <p>There are two kinds of <em>mai</em>: <em>mai</em> proper and <em>hataraki</em>. Both share a basic
+            structure. They typically start upstage, move forward, then to the stage-right corner and after circling one
+            or more times return to where they started. Depending on the character of the protagonist either can be slow
+            or fast, the gestures could be more sharp or fluid, and the relationship to the beat strict or flexible. The
+            difference between the two is mostly in the longer duration and larger number of subsections in <em>mai</em>
+            than in <em>hataraki</em>. The former is normally more of a stand-alone scene, while the latter, functions
+            as a brief underlining of the moment's mood, emotional coloring or dramatic action. <em>Hataraki</em> can be
+            composed of passages that enact a narrative in the play's present like exorcisms or fight scenes.
+            <em>Jonomai</em> from Hashitomi is an example of <em>mai</em>, while <em>maibataraki</em>, represents a
+            <em>hataraki</em></p>
+          <H3 id="Shimai">Shimai and Maibayashi</H3>
+          <p>Besides dance in the context of a Noh play, there are two other forms of dance. Dance-to-text
+            <em>shōdan</em>, such as <em>kuse</em> and <em>kiri</em>, can be performed independently from a play. This
+            form of dance called <em>shimai</em> includes a jiutai usually composed of four members, but no
+            <em>hayashi</em>.<br>
+            Instrumental dances can also be performed independently from a play. This form of dance called
+            <em>maibayashi</em> includes a <em>hayashi</em> and a jiutai with a membership that can vary between three
+            and eight singers.</p>
 
-<p>When performing a <em>shimai</em> or <em>maibayashi</em>, the dancer is not masked, carries a simpler type of fan, and wears a crest-adorned <em>kimono</em> and <em>hakama</em> rather than a costume. Members of jiutai handle their fans differently. They hold the fan upwards when singing in a play, but hold it resting on their laps when singing in a <em>shimai</em> or <em>maibayashi</em>.</p>
+          <p>When performing a <em>shimai</em> or <em>maibayashi</em>, the dancer is not masked and wears a
+            crest-adorned <em>kimono</em> and <em>hakama</em> rather than a costume. Moreover, the fan is larger than
+            the one used in a play, and it is handled differently by the members of the jiutai. Whereas they kneel with
+            hands in their pockets, fans resting on the stage floor when inactive, they hold the fan upwards when
+            singing in a play, but hold it resting on their laps when singing in a <em>shimai</em> or
+            <em>maibayashi</em>.</p>
 
-<h3></h3>
-<p>For video examples and analysis of shimai from Hashitomi and Kokaji please refer to <a href="/shimai-dances/" target="_blank">Shimai Dances</a>. The recordings feature KONGŌ Tatsunori accompanied by the chanting of brothers UDAKA Tatsushige and Norishige.</p>
-<h3></h3>
-<p> For more information about movement please see an extended chapter at the <a href="https://jparc.online/nogaku/performance/movement/">JPARC Nōgaku Site</a>.</p>
-  </div>
-  </section>
+          <h3></h3>
+          <p>For video examples and analysis of shimai from Hashitomi and Kokaji please refer to <a
+              href="/shimai-dances/" target="_blank">Shimai Dances</a>. The recordings feature KONGŌ Tatsunori
+            accompanied by the chanting of brothers UDAKA Tatsushige and Norishige.</p>
+          <h3></h3>
+          <p> For more information about movement please see an extended chapter at the <a
+              href="https://jparc.online/nogaku/performance/movement/">JPARC Nōgaku Site</a>.</p>
+        </div>
+      </section>
+    </div>
   </div>
 </main>

--- a/src/form.html
+++ b/src/form.html
@@ -8,298 +8,296 @@ permalink: /form/
 
 {% include second-menu-elements.html %}
 
-
-
 <main class="page-content">
   <div class="text-container">
 
-        <div class="wrapper sidebar-contents">
-          <aside class="sidebar-contents__table">
-            {% include menu-form.html %}
-          </aside>
-          <section class="sidebar-contents__section">
-            <h2 id="Intro">Form</h2>
-
-        <p>Zeami is credited with having perfected Noh as it still exists today. When it came to form, he adapted the Gagaku concept of modulation and movement called <em>Jo-ha-kyū</em>. The tripartite can be summarized as: <em>Jo</em> - slow introduction, <em>Ha</em> - development and acceleration, and <em>kyū</em> - fast conclusion. It suggests that most efforts should start slowly and clamly, speed up and gain energy, before rapidly ending while at a high point. Eventually, the principle of <em>Jo-ha-kyū</em> was applied to various levels of organization. For instance, its basic idea of acceleration has shaped the line of <a href="/catalog-of-shodan/nanori" target="_blank">declamation</a> and structure of <a href="/movement/forward/" target="_blank">movement</a>, among others. </p>
-                <p>Within a Noh play, Zeami expanded the model from three to five sections by nesting the <em>Jo-ha-kyū</em> within the <em>Ha</em>, the tripartite’s longest section. Thus, his adaptation can be summarized as: <em>Jo, Ha-jo, Ha-ha, Ha-kyū, Kyū</em>.</p>
-
-                <table class="content-table">
-
-                <tr class="content-table__row--header">
-                          <td id="hashitomi-first-act" class="content-table__column"><h4>Act 1</h4></td>
-                          <td class="content-table__column"></td>
-                          <td class="content-table__column"></td>
-                          <td class="content-table__column"></td>
-                          <td id="hashitomi-first-act" class="content-table__column"><h4>Act 2</h4></td>
-                </tr>
-
-                <tr class="content-table__row">
-
-                            <td class="content-table__column">Jo</td>
-                            <td class="content-table__column">Ha<br>(Jo</td>
-                            <td class="content-table__column"><br>Ha</td>
-                            <td class="content-table__column"><br>Kyū)</td>
-                            <td class="content-table__column">Kyū</td>
-
-                </tr>
-                </table>
-
-
-        <p>This construction is typically found in the dramas from the God's category such as <em>Takasago</em> and <em>Yumiyawata</em>, which were written by Zeami himself. However, this model was an ideal that has proven itself too limiting as the structure for all the different plays. Even Zeami once wrote that a certain warrior play could be expanded beyond the normal five sections.  The actual composition of a noh drama was dictated more by the dramatic content than the 5 sections based on the jo-ha-kyū.</p>
-
-          <h3 id="Dan">Dan</h3>
-
-          <p>The formal organization through the jo-ha-kyū principle established that a noh drama consists of sections referred to in noh terminology as <em>dan</em>. These were further defined in relation to shite, waki and their actions.  Inspired by analyses of 20th century scholars like Frank Hoff & Willi Flindt <a href="#footnote">*)</a>, we have adopted an analyticial structure of two acts, each one divided into five <em>dan</em>, according to the following sequences:</p>
-
-          <table class="content-table">
-
-          <tr class="content-table__row">
-                    <td class="content-table__column"><h4>Act 1</h4></td>
-                    <td class="content-table__column"><h5>Waki Enters</h5></td>
-                    <td class="content-table__column"><h5>Shite Enters</h5></td>
-                    <td class="content-table__column"><h5>Dialogue</h5></td>
-                    <td class="content-table__column"><h5>Shite Performs</h5></td>
-                    <td class="content-table__column"><h5>Shite Exits</h5></td>
-          </tr>
-
-          <tr class="content-table__row">
-                    <td class="content-table__column"><h4>Act 2</h4></td>
-                    <td class="content-table__column"><h5>Waki Waits</h5></td>
-                    <td class="content-table__column"><h5>Shite Re-enters</h5></td>
-                    <td class="content-table__column"><h5>Dialogue</h5></td>
-                    <td class="content-table__column"><h5>Shite Performs</h5></td>
-                    <td class="content-table__column"><h5>Shite Exits</h5></td>
-          </tr>
-          </table>
-
-        <p>A <em>nakairi</em> is often performed between the two acts. Usually, an <a href="/music/voices/#Ai" target="_blank">ai-kyōgen</a> enters at that time and engages with the waki. Acting as a local who is well informed about the place’s history, he introduces information that complements and connects the first and second acts. Performed by a kyōgen actor, the section is seen as external to noh and is not categorized within its stuctural terms like dan or shōdan.</p>
-
-        <h3 id="shodan">Shōdan</h3>
-      <p>Each dan represents a fixed combination from one to several modules called <em>shōdan</em>.  The shōdan are standardized and are found in various plays, where they serve similar structural and dramatic functions and characteristics. Some of them also have a syntactical order where particular one typically follows another. There are about one hundred different types of <em>shōdan</em> that can be categorized as four types: Spoken, Chanted, Entrance and Exit Music, and Dance Music. For more information about individual shōdan and video examples please refer to the <a href="/catalog-of-shodan/" target="_blank">Catalog of Shōdan</a>.</p>
-
-
-
-        <h3 id="Hashitomi">The Form of Hashitomi</h3>
-
-        <p>Hashitomi and Kokaji’s forms shown below prove that Zeami’s design should be viewed only as a reference. Moreover, both in their own way deviate from the contemporary analytical model too.</p>
-
-
-        <p>The figure below summarizes Hashitomi's form. The play omits ‘Shite Performs’ section in the first act, a difference that is not unique to Hashitomi. </p>
-
-        <p>[In the following figures, the section's name is linked to the beginning of that section within the play, while the <em>shōdan</em> names are linked to their respective intermedia analysis.]</p>
-
-        <table class="content-table">
-
-        <tr class="content-table__row--header">
-                  <td id="hashitomi-first-act" class="content-table__column"><h4>Act 1</h4></td>
-                  <td class="content-table__column"></td>
-                  <td class="content-table__column"></td>
-                  <td class="content-table__column"></td>
-                  <td class="content-table__column"></td>
-                  <td class="content-table__column"></td>
-        </tr>
-
-        <tr class="content-table__row">
-
-                    <td class="content-table__column"><h4>DAN</h4></td>
-                  <td class="content-table__column"><a href="/hashitomi/#startTime=00:04:55" target="_blank"><h5>Waki Enters</h5></a></td>
-                  <td class="content-table__column"><a href="/hashitomi/#startTime=00:08:56" target="_blank"><h5>Shite Enters</h5></a></td>
-                  <td class="content-table__column"><a href="/hashitomi/#startTime=00:14:02" target="_blank"><h5>Dialogue</h5></a></td>
-                  <td class="content-table__column"><h5>Shite Performs</h5></td>
-                  <td class="content-table__column"><a href="/hashitomi/#startTime=00:18:53" target="_blank"><h5>Shite Exits</h5></a></td>
-        </tr>
-
-        <tr class="content-table__row"></tr>
-
-        <tr class="content-table__row">
-                  <td class="content-table__column"><h4>SHŌDAN</h4></td>
-
-                  <td class="content-table__column">
-                      <a href="/hashitomi/nanoribue/" target="_blank"><em>Nanoribue</em></a><br>
-                      <a href="/hashitomi/nanori/" target="_blank"><em>Nanori</em></a><br>
-                      <a href="/hashitomi/kakaru-1/" target="_blank"><em>Kakaru 1</em></a>
-                  </td>
-
-                  <td class="content-table__column">
-                    <a href="/hashitomi/ashirai/" target="_blank"><em>Ashirai</em></a><br>
-                    <a href="/hashitomi/song/" target="_blank"><em>Song</em></a>
-                  </td>
-
-                  <td class="content-table__column">
-                    <a href="/hashitomi/kakeai/" target="_blank"><em>Kakeai</em></a><br>
-                    <a href="/hashitomi/kakaru-2/" target="_blank"><em>Kakaru 2</em></a>
-                  </td>
-
-                  <td class="content-table__column"> – </td>
-
-                  <td class="content-table__column">
-                    <a href="/hashitomi/ageuta-1/" target="_blank"><em>Ageuta 1</em></a></td>
-
-        </tr>
-        </table>
-
-        <table class="content-table">
-
-        <tr class="content-table__row--header">
-                  <td id="hashitomi-second-act" class="content-table__column"><h4>ACT 2</h4></td>
-                  <td class="content-table__column"></td>
-                  <td class="content-table__column"></td>
-                  <td class="content-table__column"></td>
-                  <td class="content-table__column"></td>
-                  <td class="content-table__column"></td>
-        </tr>
-
-        <tr class="content-table__row">
-                  <td class="content-table__column"><h4>DAN</h4></td>
-                  <td class="content-table__column"><a href="/hashitomi/#startTime=00:39:23" target="_blank"><h5>Waki Waits</h5></a></td>
-                  <td class="content-table__column"><a href="/hashitomi/#startTime=00:40:56" target="_blank"><h5>Shite Re-enters</h5></a></td>
-                  <td class="content-table__column"><a href="/hashitomi/#startTime=00:47:15" target="_blank"><h5>Dialogue</h5></a></td>
-                  <td class="content-table__column"><a href="/hashitomi/#startTime=00:51:58" target="_blank"><h5>Shite Performs</h5></td>
-                  <td class="content-table__column"><a href="/hashitomi/#startTime=01:17:26" target="_blank"><h5>Shite Exits</h5></a></td>
-        </tr>
-
-        <tr class="content-table__row"></tr>
-
-        <tr class="content-table__row">
-                    <td class="content-table__column"><h4>SHŌDAN</h4></td>
-                    <td class="content-table__column">
-                      <a href="/hashitomi/kakaru-3/" target="_blank"><em>Kakaru 3</em></a>
-                  </td>
-
-                  <td class="content-table__column">
-                    <a href="/hashitomi/issei/" target="_blank"><em>Issei</em></a><br>
-        <a href="/hashitomi/sageuta/" target="_blank"><em>Sageuta</em></a><br>
-        <a href="/hashitomi/ageuta-2/" target="_blank"><em>Ageuta 2</em></a>
-                  </td>
-
-                  <td class="content-table__column">
-                    <a href="/hashitomi/rongi/" target="_blank"><em>Rongi</em></a></td>
-
-                  <td class="content-table__column">
-        <a href="/hashitomi/kuse/" target="_blank"><em>Kuse</em></a><br>
-        <a href="/hashitomi/jonomai/" target="_blank"><em>Jonomai</em></a>
-        </td>
-                  <td class="content-table__column">
-                    <a href="/hashitomi/waka/" target="_blank"><em>Waka</em></a><br>
-        <a href="/hashitomi/kiri/" target="_blank"><em>Kiri</em></a>
-        </td>
-
-        </tr>
-        </table>
-
-
-<h3 id="Kokaji">The Form of Kokaji</h3>
-
-        <p>The figure below summarizes Kokaji's form. The play omits ‘Dialogue’ section in the second act, a difference that is not unique to Kokaji.</p>
-
-        <table class="content-table">
-
-          <tr class="content-table__row--header">
-                  <td id="hashitomi-first-act" class="content-table__column"><h4>Act 1</h4></td>
-                  <td class="content-table__column"></td>
-                  <td class="content-table__column"></td>
-                  <td class="content-table__column"></td>
-                  <td class="content-table__column"></td>
-                  <td class="content-table__column"></td>
-        </tr>
-
-        <tr class="content-table__row">
-
-                    <td class="content-table__column"><h4>DAN</h4></td>
-                  <td class="content-table__column"><a href="/kokaji/#startTime=00:03:55" target="_blank"><h5>Waki Enters</h5></a></td>
-                  <td class="content-table__column"><a href="/kokaji/#startTime=00:10:46" target="_blank"><h5>Shite Enters</h5></a></td>
-                  <td class="content-table__column"><a href="/kokaji/#startTime=00:12:18" target="_blank"><h5>Dialogue</h5></a></td>
-                  <td class="content-table__column"><a href="/kokaji/#startTime=00:16:55" target="_blank"><h5>Shite Performs</h5></a></td>
-                  <td class="content-table__column"><a href="/kokaji/#startTime=00:29:07" target="_blank"><h5>Shite Exits</h5></a></td>
-        </tr>
-
-        <tr class="content-table__row"></tr>
-
-        <tr class="content-table__row">
-          <td class="content-table__column"><h4>SHŌDAN</h4></td>
-                  <td class="content-table__column">
-                      <a href="/kokaji/nanori/" target="_blank"><em>Nanori</em></a><br>
-        <a href="/kokaji/mondo-1/" target="_blank"><em>Mondō 1</em></a><br>
-        <a href="/kokaji/ageuta-1/" target="_blank"><em>Ageuta 1</em></a>
-         </td>
-
-                  <td class="content-table__column">
-                    <a href="/kokaji/dialogue/" target="_blank"><em>Dialogue</em></a><br>
-        <a href="/kokaji/monologue/" target="_blank"><em>Monologue</em></a>
-                  </td>
-
-                  <td class="content-table__column">
-                    <a href="/kokaji/mondo-2/" target="_blank"><em>Mondō 2</em></a><br>
-        <a href="/kokaji/ageuta-2/" target="_blank"><em>Ageuta 2</em></a>
-                  </td>
-
-
-                  <td class="content-table__column">
-        <a href="/kokaji/kuri/" target="_blank"><em>Kuri</em></a><br>
-        <a href="/kokaji/sashi/" target="_blank"><em>Sashi</em></a><br>
-        <a href="/kokaji/kuse/" target="_blank"><em>Kuse</em></a>
-         </td>
-
-                  <td class="content-table__column">
-                    <a href="/kokaji/kakeai-1/" target="_blank"><em>Kakeai 1</em></a><br>
-        <a href="/kokaji/ageuta-3/" target="_blank"><em>Ageuta 3</em></a><br>
-        <a href="/kokaji/raijo/" target="_blank"><em>Raijo</em></a>
-        </td>
-
-        </tr>
-        </table>
-
-        <table class="content-table">
-
-        <tr class="content-table__row--header">
-                  <td id="hashitomi-second-act" class="content-table__column"><h4>ACT 2</h4></td>
-                  <td class="content-table__column"></td>
-                  <td class="content-table__column"></td>
-                  <td class="content-table__column"></td>
-                  <td class="content-table__column"></td>
-                  <td class="content-table__column"></td>
-        </tr>
-
-        <tr class="content-table__row">
-                  <td class="content-table__column"><h4>DAN</h4></td>
-                  <td class="content-table__column"><a href="/kokaji/#startTime=00:45:14" target="_blank"><h5>Waki Waits</h5></a></td>
-                  <td class="content-table__column"><a href="/kokaji/#startTime=00:51:07" target="_blank"><h5>Shite Re-enters</h5></a></td>
-                  <td class="content-table__column"><h5>Dialogue</h5></td>
-                  <td class="content-table__column"><a href="/kokaji/#startTime=00:52:30" target="_blank"><h5>Shite Performs</h5></a></td>
-                  <td class="content-table__column"><a href="/kokaji/#startTime=00:56:10" target="_blank"><h5>Shite Exits</h5></a></td>
-        </tr>
-
-        <tr class="content-table__row"></tr>
-
-        <tr class="content-table__row">
-          <td class="content-table__column"><h4>SHŌDAN</h4></td>
-                  <td class="content-table__column">
-                      <a href="/kokaji/notto/" target="_blank"><em>Notto</em></a><br>
-        <a href="/kokaji/noriji-1/" target="_blank"><em>Noriji 1</em></a>
-
-                  </td>
-
-                  <td class="content-table__column">
-                    <a href="/kokaji/hayafue/" target="_blank"><em>Hayafue</em></a>
-        </td>
-
-                  <td class="content-table__column"> –  </td>
-
-                  <td class="content-table__column">
-        <a href="/kokaji/noriji-2/" target="_blank"><em>Noriji 2</em></a><br>
-        <a href="/kokaji/maibataraki/" target="_blank"><em>Maibataraki</em></a><br>
-        <a href="/kokaji/noriji-3/" target="_blank"><em>Noriji 3</em></a>
-        </td>
-                  <td class="content-table__column">
-                    <a href="/kokaji/kakeai-2/" target="_blank"><em>Kakeai 2</em></a><br>
-        <a href="/kokaji/kiri/" target="_blank"><em>Kiri</em></a>
-        </td>
-
-        </tr>
-        </table>
-<p id="footnote"> *) Frank Hoff & Willi Flindt, “The Life Structure of <em>Noh</em>,” <em>Concerned Theatre Japan</em>, Vol. 2, No. 34, 1973,</p>
-
-    </section>
-      </div>
+    <div class="wrapper sidebar-contents">
+      <aside class="sidebar-contents__table">
+        {% include menu-form.html %}
+      </aside>
+      <section class="sidebar-contents__section">
+        <div class="text-container">
+          <h2 id="Intro">Form</h2>
+
+          <p>Zeami (c.1363- c.1443) is credited with having perfected Noh as it exists today. When it came to form, he
+            adapted the Gagaku concept of modulation and movement called <em>Jo-ha-kyū</em>. The tripartite can be
+            summarized as: <em>Jo</em> - slow, <em>Ha</em> - development / acceleration, and <em>kyū</em> - fast
+            conclusion, suggesting that most efforts should start slowly, speed up, before rapidly ending. Zeami
+            expanded the model from three to five sections by incorporating the <em>Jo-ha-kyū</em> concept into the
+            <em>Ha</em>, the tripartite’s longest section. Thus, his adaptation can be summarized as: <em>Jo, Ha-jo,
+              Ha-ha, Ha-kyū, Kyū</em>.</p>
+
+          <p>Eventually, the principle of <em>Jo-ha-kyū</em> was applied to various levels of organization. For
+            instance, its basic idea of acceleration has shaped <a href="/catalog-of-shodan/nanori"
+              target="_blank">declamation</a> and <a href="/movement/forward/" target="_blank">movements</a>, among
+            others. Moreover, during the Edo period (1603-1868) Zeami's five-section structure was used as the basis for
+            the categorization of the plays, where classification was determined first and foremost by the type of shite
+            but also by elements such as the type of dance performed in the play, the subject matter, and the dramatic
+            construction, among others:
+            <p>Category 1 (± 16% of the repertoire): The shite is often a deity and these plays have a religious and
+              ceremonial undertone.<br>
+              Category 2 (± 7% of the repertoire): The shite is often the ghost of a warrior who died in battle. <br>
+              Category 3 (± 17% of the repertoire): The shite is usually a young and beautiful woman. <br>
+              Category 4 (± 38% of the repertoire): The shite is a mad or revengeful character, among several other
+              options. <br>
+              Category 5 (± 22% of the repertoire): The shite is often a dragon or demon.</p>
+            <p>Consequently, a full Noh performance used to include five plays, one of each categories, performed in the
+              order corresponding to its category's number.</p>
+
+            <p>Although there are few one-act plays, Zeami’s contribution includes defining the basic formal structure
+              of the two-act play. Based on his five-section adaptation of the <em>Jo-ha-kyū</em> concept, he proposed
+              two acts, each one divided up into five sections (<em>dan</em>), according to the following sequence of
+              actions:</p>
+
+            <p>First act (<em>mae ba</em>): Waki Enters, Shite Enters, Dialogue, Shite Performs, and Shite Exits<br>
+              Second act (<em>nochi ba</em>): Waki Waits, Shite Re-enters, Dialogue, Shite Performs, and Shite Exits</p>
+
+
+            <p>A <em>nakairi</em> is often performed between the two acts, yet there are no <em>shōdan</em> associated
+              with it. Usually, an <a href="/music/voices/#Ai" target="_blank">ai-kyōgen</a> enters at that moment and
+              engages with the waki. Acting as a local who is well informed about the place’s history, he introduces
+              information that connects the first and second acts.</p>
+
+            <h3 id="shodan">Shōdan</h3>
+            <p>The music of Noh can be seen as modular not only because of the prescribed vocabulary of melodic and
+              rhythmic patterns that are reused in multiple plays, but also because these patterns form larger standard
+              modules (<em>shōdan</em>) that are found in various plays, where they serve similar structural and
+              dramatic functions. There are about one hundred different types of <em>shōdan</em> that can be categorized
+              into four types: Spoken, Chanted, Entrance and Exit music, and Dance music. For more information and video
+              examples please refer to the <a href="/catalog-of-shodan/" target="_blank">Catalog of Shōdan</a>.</p>
+
+
+            <h3 id="Hashitomi">The Form of Hashitomi and Kokaji</h3>
+
+            <p>Zeami’s formal design should be viewed as a reference rather than an absolute, since few plays follow it
+              thoroughly. Hashitomi and Kokaji’s form clearly underlines this point, since in their own way they both
+              somewhat deviate from his model.</p>
+            <p>In the following two figures, the section's name is linked to the beginning of that section within the
+              play, while the <em>shōdan</em> are linked to their respective intermedia analysis.</p>
+
+
+            <p>This figure summarizes Hashitomi's form. It differs from Zeami’s model primarily with the missing ‘Shite
+              Performs’ section in the first act, a difference that is not unique to Hashitomi.</p>
+
+            <table class="content-table">
+
+              <tr class="content-table__row--header">
+                <td id="hashitomi-first-act" class="content-table__column">First act <br>(<em>mae ba</em>)</td>
+                <td class="content-table__column"></td>
+                <td class="content-table__column"></td>
+                <td class="content-table__column"></td>
+                <td class="content-table__column"></td>
+              </tr>
+
+              <tr class="content-table__row">
+                <td class="content-table__column"><a href="/hashitomi/#startTime=00:04:55" target="_blank">Waki
+                    Enters</a></td>
+                <td class="content-table__column"><a href="/hashitomi/#startTime=00:08:56" target="_blank">Shite
+                    Enters</a></td>
+                <td class="content-table__column"><a href="/hashitomi/#startTime=00:14:02" target="_blank">Dialogue</a>
+                </td>
+                <td class="content-table__column">
+                  <p>Shite Performs</p>
+                </td>
+                <td class="content-table__column"><a href="/hashitomi/#startTime=00:18:53" target="_blank">Shite
+                    Exits</a></td>
+              </tr>
+
+              <tr class="content-table__row"></tr>
+
+              <tr class="content-table__row">
+                <td class="content-table__column">
+                  <a href="/hashitomi/nanoribue/" target="_blank"><em>Nanoribue</em></a><br>
+                  <a href="/hashitomi/nanori/" target="_blank"><em>Nanori</em></a><br>
+                  <a href="/hashitomi/kakaru-1/" target="_blank"><em>Kakaru 1</em></a>
+                </td>
+
+                <td class="content-table__column">
+                  <a href="/hashitomi/ashirai/" target="_blank"><em>Ashirai</em></a><br>
+                  <a href="/hashitomi/song/" target="_blank"><em>Song</em></a>
+                </td>
+
+                <td class="content-table__column">
+                  <a href="/hashitomi/kakeai/" target="_blank"><em>Kakeai</em></a><br>
+                  <a href="/hashitomi/kakaru-2/" target="_blank"><em>Kakaru 2</em></a>
+                </td>
+
+                <td class="content-table__column"> – </td>
+
+                <td class="content-table__column">
+                  <a href="/hashitomi/ageuta-1/" target="_blank"><em>Ageuta 1</em></a></td>
+
+              </tr>
+            </table>
+
+            <table class="content-table">
+
+              <tr class="content-table__row--header">
+                <td id="hashitomi-second-act" class="content-table__column">Second act <br>(<em>nochi ba</em>)</td>
+                <td class="content-table__column"></td>
+                <td class="content-table__column"></td>
+                <td class="content-table__column"></td>
+                <td class="content-table__column"></td>
+              </tr>
+
+              <tr class="content-table__row">
+                <td class="content-table__column"><a href="/hashitomi/#startTime=00:39:23" target="_blank">Waki
+                    Waits</a></td>
+                <td class="content-table__column"><a href="/hashitomi/#startTime=00:40:56" target="_blank">Shite
+                    Re-enters</a></td>
+                <td class="content-table__column"><a href="/hashitomi/#startTime=00:47:15" target="_blank">Dialogue</a>
+                </td>
+                <td class="content-table__column"><a href="/hashitomi/#startTime=00:51:58" target="_blank">Shite
+                    Performs</td>
+                <td class="content-table__column"><a href="/hashitomi/#startTime=01:17:26" target="_blank">Shite
+                    Exits</a></td>
+              </tr>
+
+              <tr class="content-table__row"></tr>
+
+              <tr class="content-table__row">
+                <td class="content-table__column">
+                  <a href="/hashitomi/kakaru-3/" target="_blank"><em>Kakaru 3</em></a>
+                </td>
+
+                <td class="content-table__column">
+                  <a href="/hashitomi/issei/" target="_blank"><em>Issei</em></a><br>
+                  <a href="/hashitomi/sageuta/" target="_blank"><em>Sageuta</em></a><br>
+                  <a href="/hashitomi/ageuta-2/" target="_blank"><em>Ageuta 2</em></a>
+                </td>
+
+                <td class="content-table__column">
+                  <a href="/hashitomi/rongi/" target="_blank"><em>Rongi</em></a></td>
+
+                <td class="content-table__column">
+                  <a href="/hashitomi/kuse/" target="_blank"><em>Kuse</em></a><br>
+                  <a href="/hashitomi/jonomai/" target="_blank"><em>Jonomai</em></a>
+                </td>
+                <td class="content-table__column">
+                  <a href="/hashitomi/waka/" target="_blank"><em>Waka</em></a><br>
+                  <a href="/hashitomi/kiri/" target="_blank"><em>Kiri</em></a>
+                </td>
+
+              </tr>
+            </table>
+
+            <h3 id="Kokaji">The Form of Kokaji</h3>
+
+            <p>The figure below summarizes Kokaji's form. It differs from Zeami’s model primarily with the missing
+              ‘Dialogue’ section in the second act, a difference that is not unique to Kokaji.</p>
+
+            <table class="content-table">
+
+              <tr class="content-table__row--header">
+                <td id="kokaji-first-act" class="content-table__column">First act <br>(<em>mae ba</em>)</td>
+                <td class="content-table__column"></td>
+                <td class="content-table__column"></td>
+                <td class="content-table__column"></td>
+                <td class="content-table__column"></td>
+              </tr>
+
+              <tr class="content-table__row">
+                <td class="content-table__column"><a href="/kokaji/#startTime=00:03:55" target="_blank">Waki Enters</a>
+                </td>
+                <td class="content-table__column"><a href="/kokaji/#startTime=00:10:46" target="_blank">Shite Enters</a>
+                </td>
+                <td class="content-table__column"><a href="/kokaji/#startTime=00:12:18" target="_blank"> Dialogue</a>
+                </td>
+                <td class="content-table__column"><a href="/kokaji/#startTime=00:16:55" target="_blank"> Shite
+                    Performs</a></td>
+                <td class="content-table__column"><a href="/kokaji/#startTime=00:29:07" target="_blank"> Shite Exits</a>
+                </td>
+              </tr>
+
+              <tr class="content-table__row"></tr>
+
+              <tr class="content-table__row">
+                <td class="content-table__column">
+                  <a href="/kokaji/nanori/" target="_blank"><em>Nanori</em></a><br>
+                  <a href="/kokaji/mondo-1/" target="_blank"><em>Mondō 1</em></a><br>
+                  <a href="/kokaji/ageuta-1/" target="_blank"><em>Ageuta 1</em></a>
+                </td>
+
+                <td class="content-table__column">
+                  <a href="/kokaji/dialogue/" target="_blank"><em>Dialogue</em></a><br>
+                  <a href="/kokaji/monologue/" target="_blank"><em>Monologue</em></a>
+                </td>
+
+                <td class="content-table__column">
+                  <a href="/kokaji/mondo-2/" target="_blank"><em>Mondō 2</em></a><br>
+                  <a href="/kokaji/ageuta-2/" target="_blank"><em>Ageuta 2</em></a>
+                </td>
+
+
+                <td class="content-table__column">
+                  <a href="/kokaji/kuri/" target="_blank"><em>Kuri</em></a><br>
+                  <a href="/kokaji/sashi/" target="_blank"><em>Sashi</em></a><br>
+                  <a href="/kokaji/kuse/" target="_blank"><em>Kuse</em></a>
+                </td>
+
+                <td class="content-table__column">
+                  <a href="/kokaji/kakeai-1/" target="_blank"><em>Kakeai 1</em></a><br>
+                  <a href="/kokaji/ageuta-3/" target="_blank"><em>Ageuta 3</em></a><br>
+                  <a href="/kokaji/raijo/" target="_blank"><em>Raijo</em></a>
+                </td>
+
+              </tr>
+            </table>
+
+            <table class="content-table">
+
+              <tr class="content-table__row--header">
+                <td id="kokaji-second-act" class="content-table__column">Second act <br>(<em>nochi ba</em>)</td>
+                <td class="content-table__column"></td>
+                <td class="content-table__column"></td>
+                <td class="content-table__column"></td>
+                <td class="content-table__column"></td>
+              </tr>
+
+              <tr class="content-table__row">
+                <td class="content-table__column"><a href="/kokaji/#startTime=00:45:14" target="_blank"> Waki Waits</a>
+                </td>
+                <td class="content-table__column"><a href="/kokaji/#startTime=00:51:07" target="_blank"> Shite
+                    Re-enters</a></td>
+                <td class="content-table__column">
+                  <p>Dialogue</p>
+                </td>
+                <td class="content-table__column"><a href="/kokaji/#startTime=00:52:30" target="_blank"> Shite
+                    Performs</a></td>
+                <td class="content-table__column"><a href="/kokaji/#startTime=00:56:10" target="_blank"> Shite Exits</a>
+                </td>
+              </tr>
+
+              <tr class="content-table__row"></tr>
+
+              <tr class="content-table__row">
+                <td class="content-table__column">
+                  <a href="/kokaji/notto/" target="_blank"><em>Notto</em></a><br>
+                  <a href="/kokaji/noriji-1/" target="_blank"><em>Noriji 1</em></a>
+
+                </td>
+
+                <td class="content-table__column">
+                  <a href="/kokaji/hayafue/" target="_blank"><em>Hayafue</em></a>
+                </td>
+
+                <td class="content-table__column"> – </td>
+
+                <td class="content-table__column">
+                  <a href="/kokaji/noriji-2/" target="_blank"><em>Noriji 2</em></a><br>
+                  <a href="/kokaji/maibataraki/" target="_blank"><em>Maibataraki</em></a><br>
+                  <a href="/kokaji/noriji-3/" target="_blank"><em>Noriji 3</em></a>
+                </td>
+                <td class="content-table__column">
+                  <a href="/kokaji/kakeai-2/" target="_blank"><em>Kakeai 2</em></a><br>
+                  <a href="/kokaji/kiri/" target="_blank"><em>Kiri</em></a>
+                </td>
+
+              </tr>
+            </table>
+
+        </div>
+      </section>
+    </div>
   </div>
 </main>

--- a/src/music.html
+++ b/src/music.html
@@ -1,5 +1,6 @@
 ---
 layout: website
+title: Music
 menu-active: elements
 second-level-menu-active: music
 permalink: /music/
@@ -11,63 +12,138 @@ permalink: /music/
   <div class="text-container">
     {% include menu-instrument-large.html %}
     <div class="wrapper sidebar-contents">
+
       <aside class="sidebar-contents__table">
         {% include menu-music.html %}
       </aside>
       <section class="sidebar-contents__section">
+        <div class="text-container">
+          <h2>Music</h2>
 
-    <h2>Music</h2>
+          <p>
+            Noh relies greatly on musical expression. Its structure, emotive tone and narrative flow are carried in
+            great part by the singing of actors and the accompaniment of an instrumental ensemble. Music is present
+            throughout. It begins with highly evocative tuning (<em>oshirabe</em>) and continues through intoned
+            recitations, chant and instrumental numbers. One does not hear music only during certain entrances or exits
+            of actors or for moving of stage properties. </p>
 
-    <p>
-      Noh relies greatly on musical expression. Its structure, emotive tone and narrative flow are carried in great part by the singing of actors and the accompaniment of an instrumental ensemble. Music is present throughout. It begins with highly evocative tuning (<em>oshirabe</em>) and continues through intoned recitations, chant and instrumental numbers. One does not hear music only during certain entrances or exits of actors or for moving of stage properties. </p>
+          <h3 id="Performers">Performers</h3>
+          <p>The <a href="/music/voices" target="_blank">vocal music</a> in the form of Noh chant (<em>utai</em>) plays
+            a central role and is performed by a principal actor (<em>shite</em>), a supporting actor (<em>waki</em>), a
+            kyōgen actor (<em>ai</em>) and chorus (<em>jiutai</em>). The instrumental ensemble and its music
+            (<em>hayashi</em>) serve to accompany singing, dances, and entrances and exits of actors. It is comprised of
+            one pitched instrument: the <a href="/music/nohkan" target="_blank">nohkan</a> (noh flute), and two
+            unpitched percussion instruments: the <a href="/music/otsuzumi-kotsuzumi">ōtsuzumi</a> (hip drum) and <a
+              href="/music/otsuzumi-kotsuzumi">kotsuzumi</a> (shoulder drum). About half of the plays in current
+            repertoire include a third drum, the <a href="/music/taiko" target="_blank">taiko</a> (stick drum). With a
+            few rare exceptions taiko only joins in for the second half of a play. Between percussion strokes the
+            drummers perform highly expressive vocal calls (<em>kakegoe</em>) that provide an original vocal dimension
+            even in the accompanying parts.</p>
 
-    <h3 id="Performers">Performers</h3>
-    <p>The <a href="/music/voices" target="_blank">vocal music</a> in the form of Noh chant (<em>utai</em>) plays a central role and is performed by a principal actor (<em>shite</em>), a supporting actor (<em>waki</em>), a kyōgen actor (<em>ai</em>) and chorus (<em>jiutai</em>). The instrumental ensemble and its music (<em>hayashi</em>) serve to accompany singing, dances, and entrances and exits of actors. It is comprised of one pitched instrument: the <a href="/music/nohkan" target="_blank">nohkan</a> (noh flute), and two unpitched percussion instruments: the <a href="/music/otsuzumi-kotsuzumi">ōtsuzumi</a> (hip drum) and <a href="/music/otsuzumi-kotsuzumi">kotsuzumi</a> (shoulder drum). About half of the plays in current repertoire include a third drum, the <a href="/music/taiko" target="_blank">taiko</a> (stick drum).  With a few rare exceptions taiko only joins in for the second half of a play. Between percussion strokes the drummers perform highly expressive vocal calls (<em>kakegoe</em>) that provide an original vocal dimension even in the accompanying parts.</p>
+          <h3 id="Rhythm">Rhythmic Organization</h3>
+          <p>The rhythmic organization in Noh is highly sophisticated, complex and carries immense dramatic potential.
+            Its basic unit of time is an 8-beat measure (<em>honji</em>), which is used for all instrumental music, such
+            as dance, entrance and exit music. It is also the basic unit of time for vocal music but in this case, it is
+            possible to sporadically encounter measures of 2, 4, or 6 beats, used to accommodate the syllabic structure
+            of the text. Despite this mostly fixed underlying structure, the immense flexibility of the individual beats
+            and multiple ways of synchronization between instruments result in great rhythmic variety and expressive
+            richness.</p>
 
-    <h3 id="Rhythm">Rhythmic Organization</h3>
-    <p>The rhythmic organization in Noh is highly sophisticated, complex and carries immense dramatic potential. Its basic unit of time is an 8-beat measure (<em>honji</em>), which is used for all instrumental music, such as dance, entrance and exit music. It is also the basic unit of time for vocal music but in this case, it is possible to sporadically encounter measures of 2, 4, or 6 beats, used to accommodate the syllabic structure of the text. Despite this mostly fixed underlying structure, the immense flexibility of the individual beats and multiple ways of synchronization between instruments result in great rhythmic variety and expressive richness.</p>
+          <p>Flexibility of pulse is the norm in Noh. The duration of each beat can be negotiated intuitively between
+            expressive needs of all performers, one beat at time. Some beats of the eight-beat unit are extended or
+            shrunk, predictably according to performance traditions. For instance, it is customary for the eighth beat
+            to be extended and for beats 1, 3 and 5 to be shrunk. When the beats are shrunk the odd beat is not followed
+            by a kakegoe. Regular pulse is almost exclusively found in dance, noriji, and some entrance music.</p>
 
-        <p>Flexibility of pulse is the norm in Noh. The duration of each beat can be negotiated intuitively between expressive needs of all performers, one beat at time. Some beats of the eight-beat unit are extended or shrunk, predictably according to performance traditions. For instance, it is customary for the eighth beat to be extended and for beats 1, 3 and 5 to be shrunk. When the beats are shrunk the odd beat is not followed by a kakegoe. Regular pulse is almost exclusively found in dance, noriji, and some entrance music.</p>
+          <p>The notion of strict synchronization between all players is also an exception rather than the norm. For
+            instance, the first beat of the eight-beat unit, which for Western ensembles would traditionally serve as an
+            accent and a point of rhythmic unity, in Noh is often silent. It is "performed" internally in the mind of
+            the musicians a process referred to as <em>komi</em>. In the video showcasing strict and flexible rhythmic
+            settings, the second, fourth and sixth beats are most of the time performed as <em>komi</em> as well. The
+            sound that follows is timed according to an individual musician's sense of pacing. The notion of
+            “togetherness” is not based on exact coincidence of the attack but on a cohesion of overall flow, energy,
+            and expression. In the same spirit, most of the time the nohkan’s part is metrically independent from the
+            percussion part and there are many instances when that is the case for the chant as well.</p>
 
-        <p>The notion of strict synchronization between all players is also an exception rather than the norm. For instance, the first beat of the eight-beat unit, which for Western ensembles would traditionally serve as an accent and a point of rhythmic unity, in Noh is often silent. It is "performed" internally in the mind of the musicians a process referred to as <em>komi</em>. In the video showcasing strict and flexible rhythmic settings, the second, fourth and sixth beats are most of the time performed as <em>komi</em> as well. The sound that follows is timed according to an individual musician's sense of pacing. The notion of “togetherness” is not based on exact coincidence of the attack but on a cohesion of overall flow, energy, and expression. In the same spirit, most of the time the nohkan’s part is metrically independent from the percussion part and there are many instances when that is the case for the chant as well.</p>
+          <p>There are two types of rhythmic correlation between the voice, flute and percussion instruments. The
+            correlation is 'congruent' when the nohkan and/or vocal parts align with the eight-beat
+            unit(<em>honji</em>), whereas it is said to be 'non-congruent' when they do not. The former provides
+            rhythmic stability, the latter rhythmic flexibility.</p>
 
-        <p>There are two types of rhythmic correlation between the voice, flute and percussion instruments. The correlation is 'congruent' when the nohkan and/or vocal parts align with the eight-beat unit(<em>honji</em>), whereas it is said to be 'non-congruent' when they do not. The former provides rhythmic stability, the latter rhythmic flexibility.</p>
+          <p>In the non-congruent rhythmic setting, the degree of independence vis-à-vis the eight-beat unit varies
+            according to the instruments: A non-congruent vocal line is totally independent from the eight-beat unit, in
+            the sense that it does not start or end on a specific beat, and at no time is it expected to align with a
+            specific beat. A non-congruent nohkan part begins and ends at some specific points often related to the
+            text, but the music between these two points in not synchronized within the 8 beat measure. </p>
 
-        <p>In the non-congruent rhythmic setting, the degree of independence vis-à-vis the eight-beat unit varies according to the instruments:  A non-congruent vocal line is totally independent from the eight-beat unit, in the sense that it does not start or end on a specific beat, and at no time is it expected to align with a specific beat.  A non-congruent nohkan part begins and ends at some specific points often related to the text, but the music between these two points in not synchronized within the 8 beat measure. </p>
+          <p> There is no conductor in noh. Most of the time chant or dance of the actors initiate and lead the musical
+            flow for all other performers. Jiutai and hayashi are next and considered equal to each other. Within
+            <em>hayashi</em> the hierarchy continues from stage right to the left. Taiko leads, if present, followed by
+            ōtsuzumi, kotsuzumi, and finally, the nohkan. This relationships can occasionally be adjusted when one of
+            the lower ranked instruments is being performed by someone of greater experience. At certain structural
+            moments it is also common that the actors wait for instrumentalist to start or finish their parts. </p>
+          <h3 id="Pitch">Pitch Organization</h3>
+          <p>The melodic language of Noh is not dependent on absolute pitches. With the nohkan being the only pitched
+            instrument there is no need for the hayashi to tune to each other. There is no expected pitch coordination
+            between nohkan and utai either although at times they share a general range that outlines a larger common
+            structure. </p>
+          <p>
+            The loudness of instruments is relatively constant. The lower register of the flute is naturally softer and
+            is used according to dramatic or formal function. The kakegoe as well as chant can match in loudness the
+            dramatic character of the scene or role. </p>
 
-    <p> There is no conductor in noh. Most of the time chant or dance of the actors initiate and lead the musical flow for all other performers. Jiutai and hayashi are next and considered equal to each other. Within <em>hayashi</em> the hierarchy continues from stage right to the left. Taiko leads, if present, followed by ōtsuzumi, kotsuzumi, and finally, the nohkan. This relationships can occasionally be adjusted when one of the lower ranked instruments is being performed by someone of greater experience. At certain structural moments it is also common that the actors wait for instrumentalist to start or finish their parts. </p>
-<h3 id="Pitch">Pitch Organization</h3>
-    <p>The melodic language of Noh is not dependent on absolute pitches. With the nohkan being the only pitched instrument there is no need for the hayashi to tune to each other. There is no expected pitch coordination between nohkan and utai either although at times they share a general range that outlines a larger common structure.  </p>
-    <p>
-    The loudness of instruments is relatively constant. The lower register of the flute is naturally softer and is used according to dramatic or formal function.  The kakegoe as well as chant can match in loudness the dramatic character of the scene or role.  </p>
+          <h3 id="Form">Form</h3>
+          <p>
+            The music in Noh draws on a common collection of rhythmic and melodic patterns. Many of the same patterns
+            occur multiple times within a single play and in different sections of a play leading to a great unity and
+            self-similarity. But this seeming limitation is well balanced by the abundance of variants and tempi, a
+            flexibility with which the patterns are sequenced into larger phrases, and by original expressive inflection
+            of specific plays and particular performances. Patterns form larger structural modules <a
+              href="/catalog-of-shodan" target="_blank">(<em>shōdan</em>)</a> that reoccur throughout the repertoire and
+            which are grouped into sections according to function within each of the two acts of a play. </p>
 
-    <h3 id="Form">Form</h3>
-    <p>
-    The music in Noh draws on a common collection of rhythmic and melodic patterns. Many of the same patterns occur multiple times within a single play and in different sections of a play leading to a great unity and self-similarity. But this seeming limitation is well balanced by the abundance of variants and tempi, a flexibility with which the patterns are sequenced into larger phrases, and by original expressive inflection of specific plays and particular performances. Patterns form larger structural modules <a href="/catalog-of-shodan" target="_blank">(<em>shōdan</em>)</a> that reoccur throughout the repertoire and which are grouped into sections according to function within each of the two acts of a play.  </p>
+          <h3 id="Transmission">Transmission</h3>
+          <p>
+            The vocal styles, instruments with their performance techniques, as well as melodic and rhythmic language
+            are unique to Noh and mastering them requires many years of specialized training. Noh is taught through oral
+            transmission. Each role and instrument has its own tradition preserved and taught within hereditary schools
+            named after their founders. There are five shite, three waki, two ai-kyōgen, five ōtsuzumi, four kotsuzumi,
+            two taiko, and three nohkan schools. Most of them publish or hand-copy summary notation of their school’s
+            individual parts but these are meant only as learning aids as all performances are done from memory.</p>
 
-    <h3 id="Transmission">Transmission</h3>
-    <p>
-    The vocal styles, instruments with their performance techniques, as well as melodic and rhythmic language are unique to Noh and mastering them requires many years of specialized training. Noh is taught through oral transmission. Each role and instrument has its own tradition preserved and taught within hereditary schools named after their founders. There are five shite, three waki, two ai-kyōgen, five ōtsuzumi, four kotsuzumi, two taiko, and three nohkan schools. Most of them publish or hand-copy summary notation of their school’s individual parts but these are meant only as learning aids as all performances are done from memory.</p>
+          <h3 id="Notation">Notation</h3>
+          <p>A clarification must be made about the music notation used on this website. Conversely to Western tradition
+            there are no complete study scores for any given play. Each of the twenty-four schools has their own
+            individual scores and variants of notation (there are five shite, three waki, two ai-kyōgen, five ōtsuzumi,
+            four kotsuzumi, two taiko, and three nohkan schools). In the performance of a Noh play, it is the school of
+            the shite that becomes the reference and it is the responsibility of the waki and ai-kyōgen actors and
+            musicians to adapt their parts to the shite’s. Scores for individual instruments are written on a grid of
+            eight blocks and they are read from top to bottom and from right to left. </p>
 
-    <h3 id="Notation">Notation</h3>
-    <p>A clarification must be made about the music notation used on this website. Conversely to Western tradition there are no complete study scores for any given play. Each of the twenty-four schools has their own individual scores and variants of notation (there are five shite, three waki, two ai-kyōgen, five ōtsuzumi, four kotsuzumi, two taiko, and three nohkan schools). In the performance of a Noh play, it is the school of the shite that becomes the reference and it is the responsibility of the waki and ai-kyōgen actors and musicians to adapt their parts to the shite’s. Scores for individual instruments are written on a grid of eight blocks and they are read from top to bottom and from right to left. </p>
+          <p>On this website, all scores combining more than one instrument are our own transcriptions. We retained the
+            characteristic note-heads of various percussion instruments’ strokes but set them on horizontal lines.
+            Occasionally, due to limited space we have provided summarized scores, merging the ōtsuzumi’s and
+            kotsuzumi’s patterns into a single line.</p>
 
-    <p>On this website, all scores combining more than one instrument are our own transcriptions. We retained the characteristic note-heads of various percussion instruments’ strokes but set them on horizontal lines. Occasionally, due to limited space we have provided summarized scores, merging the ōtsuzumi’s and kotsuzumi’s patterns into a single line.</p>
-
-    <p>For example, the following rhythmic patterns:</p>
-    {% include image-no-background.html src="/assets/images/Notation-1-Complete.png" %}
-    <p>have been notated as:</p>
-     {% include image-no-background.html src="/assets/images/Notation-1-Condensed.png" %}
+          <p>For example, the following rhythmic patterns:</p>
+          {% include image-no-background.html src="/assets/images/Notation-1-Complete.png" %}
+          <p>have been notated as:</p>
+          {% include image-no-background.html src="/assets/images/Notation-1-Condensed.png" %}
 
 
-     <p>And these patterns:</p>
-     {% include image-no-background.html src="/assets/images/Notation-2-Complete.png" %}
-     <p>have been notated as:</p>
-     {% include image-no-background.html src="/assets/images/Notation-2-Condensed.png" %}
+          <p>And these patterns:</p>
+          {% include image-no-background.html src="/assets/images/Notation-2-Complete.png" %}
+          <p>have been notated as:</p>
+          {% include image-no-background.html src="/assets/images/Notation-2-Condensed.png" %}
 
-     <p>where the left strokes on the first, third and sixth beats corresponds to the ōtsuzumi’s stroke, the right ones to the kotsuzumi’s. We have followed the same sequencing when merging <em>kakegoe</em> and stroke, thus the <em>'yo''</em> on the second half of the fourth beat is called by the ōtsuzumi player at the same time as the kotsuzumi player performs a <em>pu</em> stroke.</p>
+          <p>where the left strokes on the first, third and sixth beats corresponds to the ōtsuzumi’s stroke, the right
+            ones to the kotsuzumi’s. We have followed the same sequencing when merging <em>kakegoe</em> and stroke, thus
+            the <em>'yo''</em> on the second half of the fourth beat is called by the ōtsuzumi player at the same time
+            as the kotsuzumi player performs a <em>pu</em> stroke.</p>
 
-     <p>Finally, when the taiko is playing with the other two hand-drums, only its part has been notated.</p>
+          <p>Finally, when the taiko is playing with the other two hand-drums, only its part has been notated.</p>
+        </div>
+      </section>
+    </div>
   </div>
-  </section>
 </main>

--- a/src/plays.md
+++ b/src/plays.md
@@ -6,115 +6,323 @@ permalink: /plays/
 ---
 <main class="page-content">
 
-<div class="text-container">
+  <div class="text-container">
     <h2 id="plays-intro">Why Hashitomi and Kokaji?</h2>
     <p><em>By Tom Hare</em>
-</p>
-    <p>The modern repertory of noh comprehends more than two hundred plays, depending on how one counts them, so what is it that makes these two particular plays, <em>Kokaji</em> and <em>Hashitomi</em>, the focus of this project?</p>
-    </div>
-<div class="list-plays">
-  <div class="cards-container">
-    {% for play in site.plays %}
+    </p>
+    <p>The modern repertory of noh comprehends more than two hundred plays, depending on how one counts them, so what is
+      it that makes these two particular plays, <em>Kokaji</em> and <em>Hashitomi</em>, the focus of this project?</p>
+  </div>
+  <div class="list-plays">
+    <div class="cards-container">
+      {% for play in site.plays %}
       {% unless play.url contains "/narratives/" %}
-        {% include card.html
+      {% include card.html
           link=play.url
           image=play.image
           title=play.title
           description=play.description
         %}
       {% endunless %}
-    {% endfor %}
+      {% endfor %}
+    </div>
   </div>
-</div>
 
-<div class="text-container">
+  <div class="text-container">
 
-    <p>Books and electronic media on noh, in both Japanese and Western languages, have generally categorized their content according to the five-play system (<em>goban-date</em>) that noh troupes long ago adopted in their ordering of formal full-day programs: 1) “god-plays”, 2) “warrior-plays”, 3) “wig-plays” (or “third-category plays”), 4) “miscellaneous” or “fourth-category-plays” and 5) “demon plays” or “finale-plays”. These categories are not very precise. Not all the so-called demon plays are actually about demons. Some are about lower-ranking gods (maybe “daemon” would be a better way to translate the Japanese term) and although the “wig plays” are mostly focused on women, with actors in wigs, not all plays focused on women (even wearing wigs) are categorized as wig plays (and the main actor often wears a wig in other kinds of plays too). “Fourth-category plays are also called “miscellaneous plays,” judiciously allowing a catch-all group for plays that don’t comfortably fit anywhere else. </p>
+    <p>Books and electronic media on noh, in both Japanese and Western languages, have generally categorized their
+      content according to the five-play system (<em>goban-date</em>) that noh troupes long ago adopted in their
+      ordering of formal full-day programs: 1) “god-plays”, 2) “warrior-plays”, 3) “wig-plays” (or “third-category
+      plays”), 4) “miscellaneous” or “fourth-category-plays” and 5) “demon plays” or “finale-plays”. These categories
+      are not very precise. Not all the so-called demon plays are actually about demons. Some are about lower-ranking
+      gods (maybe “daemon” would be a better way to translate the Japanese term) and although the “wig plays” are mostly
+      focused on women, with actors in wigs, not all plays focused on women (even wearing wigs) are categorized as wig
+      plays (and the main actor often wears a wig in other kinds of plays too). “Fourth-category plays are also called
+      “miscellaneous plays,” judiciously allowing a catch-all group for plays that don’t comfortably fit anywhere else.
+    </p>
     <p>
-    Hashitomi is a wig play and Kokaji is generally considered a demon play or “fifth-category play, but in some cases it is considered a “fourth-category play.” The central figure in Kokaji is actually a god (or daemon) rather than a demon proper, which may account for its occasional placement in the fourth category.</p><p>
-For all these inconsistencies, though, the goban-date system has had a productive role in structuring occasions of performance, dating back into the seventeenth century, if not earlier. But this was still not the earliest way of categorizing the repertory of noh, or as it was known then, “sarugaku.” In the late fourteenth century, a somewhat different typology existed, at least in the writings of Zeami (1363-1443), with gods, women, warriors and demons, to be sure, but also the deranged (in most cases, women), priests, Chinese “types”, and “roles in which the main character doesn’t wear a mask.” Perhaps that was simply the way this most prominent noh actor in all the history of noh thought about categories of sarugaku performance. But even Zeami wasn’t fully committed to such a schema, since he changed to a more abstract system of “Three Modes” (Old Man, Warrior, and Woman) in the latter decades of his life. </p><p>
-The choice of Hashitomi and Kokaji for this site* doesn’t slot neatly into either of the schemes outlined above, but for all that, it provides an instructive perspective on all of them, with ties to the historical development of sarugaku into noh as well. Before we can compare the plays in this context, though, we should look at them individually, to highlight their particular characteristics, both typical and unusual. Neither play is mentioned frequently or prominently in the historical record of noh, so much of our evidence must come internally, from the plays themselves, but that is the best way to understand their structure and content anyway. </p>
-<h3 id="plays-Hashitomi">Hashitomi (or Hajitomi)</h3><p>
-As is often the case with noh, neither Hashitomi nor Kokaji can be confidently attributed to a particular author or composer.  One of the lists of the noh repertory compiled in the seventeenth-century claims that Zeami wrote Hashitomi, but this is highly unlikely. The author named in other lists of roughly the same time claims the play was written by one Naitô Saemon, or Naitô Tôzaemon, or Ninagawa; little is known about these figures apart from similar references to the authorship of two other noh plays by the said Naitô,  so perhaps he was the writer of Hashitomi after all.  But even if we cannot be fully confident in such an identification, the question of authorship nonetheless affords us a good perspective on not only Hashitomi and its reception but, more broadly, on the solidification of performance conventions in noh, inter-arts comparisons and what has been termed the “folklore” of The Tale of Genji. </p><p>
-The name Naitô Saemon or Tôzaemon itself suggests lineage in a military family, and is very different in character from the names of professional noh actors we can identify from the fourteenth and fifteenth century. It is likely that as a noh or sarugaku playwright, Naitô (or whoever composed Hashitomi) was a talented amateur, and the play bears various marks of the amateur, not just this name, as we shall see. And we should say from the start that “amateur” here is not to be taken negatively. </p><p>
-If Hashitomi bears a number of hallmarks of amateur composition, this makes it even more amenable to the identification of general characteristics of wig plays, even as it illustrates the historical development of noh in the fifteenth century more clearly than some of the more celebrated and intricately constructed plays of professionals like Zeami.</p><p>
-The central character of Hashitomi, for instance, is not readily identifiable. She bears certain associations with the famous Lady of the Evening Faces, Yûgao no Ue, in The Tale of Genji, but she could also be understood to be the spirit of the so-called yûgao plant, a type of bottle gourd with a white blossom. Such a spread of associations comes about primarily because of the choice of poems and other passages from Genji quoted, and sometimes altered, in the play.
-The quotations in question come from a variety of contexts in Genji. One is a sophisticated comparison between the moon and a departing lover, figuring the lady who longs for him on his departure to the mountain horizon.  Another requests that pinks (or dianthus flowers) deign to cast a thought, in the form of a dewdrop, onto the stakes of a dilapidated fence: this is an elaborate metaphor asking a highborn lord to look in upon his little daughter, even though her now dead mother was of undistinguished rank.   Both of these allude to important plot points early in the narrative of Genji, in connection with the ill-fated Lady of the Evening Faces, but both need the context of the tale itself to fill out the incidents in question. That, though, does not seem to be what the writer of Hashitomi intended. And yet, he was not just a magpie, picking up a snatch of poem here and a snatch of poem there. He was aiming for a different kind of sophisticated effect, if we are to judge from his use of a third poem taken from Genji. This poem appears in the play at the most conspicuous place possible, right after the shite’s jonomai at the play’s climax. Or, to be more precise, we should say that the poem sandwiches the dance, because the first line of it (altered in an interesting way) comes before the dance and then, once the dance is finished, the full poem is sung.
-In Genji, too, the poem in question comes at a crucial place; there, it serves as the pivot from simple curiosity to a fatal romantic encounter. The poem reads:
-</p><p>
-<em>Yorite koso sore ka to mo mime tasokare ni</em><br>
- <em>honobono mitsuru hana no yûgao </em><br>
-Who is it, in the deepening dusk?<br>
-Only by going up close might you see just who —<br>
-the white gourd blossom <br>
-fading out of view.
-</p><p>
-In Genji, this poem comes in response to another poem, on a slip of paper attached to a real yûgao blossom:</p><p>
-<em>Kokoro-ate ni sore ka to zo miru shiratsuyu no</em><br>
- <em>hikari soetaru yûgao no hana</em><br>
-Venturing a guess, <br>
-it looks to me just like “the very one”:<br>
-light suffuses the white dewdrops<br>
-on the blossoms of white gourd.<br>
-</p><p>
-This episode in Genji is one of its most characteristic, pairing an elite teenage male, a player in the erotic competition of the classical romance, with a beauty bereft of the political and social connections needed to maintain her position, any position, in the society of the novel.  The initial vector for contact is classical poetry, ostensibly about flowers, and these two poems allow the two lovers-to-be to break the ice and thus to further the plot of the novel.  The hidden female speaker of kokoro-ate ni is hinting that she understands it is the Shining Prince, Genji himself that passes by her cottage, with its yûgao flowers, and Genji, in his response, begs an invitation to get a closer look.
-</p><p>
-The poems also draw on a broader cultural matrix, that of an idealized classical culture of the royal court. In addition to the figural use of the gourd blossom, which links the Lady of the Evening Faces with Genji, the cultural associations of the flower, as codified and thematized in the practice of court poetry, create a rich world of associations. They also set this world in soft focus, by ambiguity and interpretive polyvalency. The word tasogare, “dusk”, for instance, provides the mise-en-scène for the gourd to blossom — it blooms at nightfall, and each blossom perdures for but a single night.  This foreshadows the brevity of a tragically brief love affair at its very inception.  It also impresses the time with an emotional character: if tasogare is dusk, it is the time when one begins to fail to recognize passers-by. Indeed, ta so gare (or kare)” in ancient Japanese means “Who is that?”
-</p><p>
-This grounding of the poem is used to specific ends in the novel, but when we consider the use of this and other poems from the classical tradition in Hashitomi, we find that those are not necessarily the same ends.
-</p><p>
-There is, for instance, a crucial single-syllable change in the way the play quotes the Genji verse. Instead of yorite koso, “Only by going up close”, the play reads orite koso, which means “only by breaking/snapping off”.  That could probably be construed to mean “take someone captive, romantically (or abusively),” but it is much more prominently a word used of gathering sprigs or branches of flowers in bloom. This interpretation fits easily into the general aesthetic context of Hashitomi, which is occasioned, according to the words of the waki in the beginning of the play, by a Buddhist service propitiating the flowers that adorn ritual altars (the rikka kuyô). With this reference, the play alludes to an intellectual debate popular in medieval Japan in which the boundaries of sentiency, and thus, of the potential for enlightenment or salvation, were disputed. The debate is not fully articulated in the play, but it’s clear enough that the composer felt plants and trees were sentient beings, and deserving of reverence. In this, he was of the same opinion, apparently, as a number of other noh playwrights, including the most celebrated.
-</p><p>
-With this, then, we begin to see Hashitomi in a somewhat broader context than merely that of an elegant tableau vivant lifted from an old tale. It then reveals links not only to Buddhist thought about the natural world, but also to an important inter-arts connection with the art of flower arranging.
-</p><p>
-This connection is, in fact, given material expression as the raison d’être for a variant performance style for the play, in *all five modern schools. That variant style, or kogaki specifies a particular prop that is not used in more conventional performances. The prop is a very large, very formal flower arrangement in an ancient style called rikka or “standing flowers”, quoted directly from Buddhist antecedents. This arrangement is stationed center-stage for the first part of the play when it is performed according to this variant, and it adds a beautiful and conspicuous supplement to the already heavily floral character of the play.
-</p><p>
-There isn’t a clear documentary trail that would tell us when the play was first done in this manner, but in that it straddles the worlds of noh performance and flower arranging, it points to the aesthetic cultivation of a time when amateurs could compose noh plays, and have them performed, and integrate them with other overt expressions to their cultural capital and inter-arts sophistication. And it is not merely in the context of noh and flower arranging that we can see this in examining Hashitomi.  In addition, we can reconsider the way the play deploys the several classical Japanese poems it quotes. If they are not used to reimagine a scene from classic literature (as other famous noh plays such as Izutsu or Atsumori do), they are nonetheless taken from self-conscious and serious aesthetic aspirations. If the poems in question don’t all come from a particular narrative context in Genji, they nonetheless share a common theme. The poem I mentioned earlier, about “the pinks . . .  casting a thought, in the form of a dewdrop, onto the stakes of a dilapidated fence,” though not from the “Lady of the Evening Faces” episode in Genji,  nonetheless comes from a foreshadowing of that episode in the previous chapter of the tale. It seems very likely — and here we would follow Janet Goff in her fine study of noh based on Genji — that the composer of Hashitomi might have discovered his thematic material for the play in the handbooks created for practitioners of linked verse (many of them amateurs), where appropriate tags from classical poetry and narrative, were collected and arranged topically for the use of latter-age versifiers.
-</p><p>
-One of the best known of those handbooks, Renju gappekishû, indeed, quotes the two poems from the encounter in Genji with the same variant first line of the response poem, orite koso, that is cited in Hashitomi.
-</p><p>
-One sees a similar propensity to playing a game of poetic allusion in some of the Chinese verses quoted in Hashitomi. Those verses come mostly from a collection of both Chinese and Japanese verse put together in the eleventh century, Wakan rôeishû, and seem less successfully integrated into the play than the Genji verses. All the same, they point to the same propensity for canvassing a broad inter-arts spectrum in order to compose the play.
-</p><p>
-The title Hashitomi (or Hajitomi) has not been the exclusive title of this play in such documentation as exists since the *seventeenth century. It has occasionally been known as Yûgao or Yûgao no Ue, provoking some confusion because there is another play of the same name in the repertory. Modern scholarly consensus has distinguished the two plays, leaving the other with the name Yûgao, pointing as well to the latter play’s more consistent and narrative-oriented use of source poems from The Tale of Genji. For this reason, the possibility has been mooted that that play was created by Zeami or at least by someone faithful to the guidelines he articulated.
-</p><p>
-That said, though, one can still identify in Hashitomi many of those same guidelines: the use of familiar poems from old classics is itself something Zeami recommended, and the focus on dance, with the fully orthodox jonomai of the final act sandwiched between lines from the central poem in the play is a common feature of many of the classic plays in the repertory. (And although the professional actors and playwrights of the fifteenth century cannot be directly credited with the jonomai, they do seem to have deployed its ancestor, the tennyo no mai as early as the 1420s.*)
-</p><p>
-From this perspective, Hashitomi differs considerably from Kokaji. Although we have even less information on who composed Kokaji than Hashitomi, and although we have no documentary evidence to show that it is an old play (of, say, the late fourteenth or early fifteenth century). It nonetheless represents an older approach to noh, or sarugaku performance, than Hashitomi, in that it is a miracle play: the claims of sarugaku tradition hold that it originated in the miraculous manifestation of a native deity at the foot of a pine tree, the Pine of Divine Revelation (yôgô no matsu) in the ancient capital Nara. Many of the oldest plays in the repertory show features of this legend. Some of them are classed as god plays according to the goban-date system I mentioned at the beginning of this essay. Others, though, often more interesting, are plays such as Kokaji, which fall into the final category, the so-called “demon” plays. The shite in Kokaji, however, is no demon, but rather the god Inari Myôjin, whose avatar is a fox.
-</p>
-<h3 id="plays-Kokaji">Kokaji</h3>
-<p>
-Something that often distinguishes “god plays” from “demon plays” in the five-genre system is interest. A few of the god plays are wonderful, but many others are rigidly formal and austere (not to say boring). The “demon plays” are never boring, and that is in part because of a plot. It’s not a complicated multi-layered plot usually, but there is a “completion of action” in such a plot: a task is set, as in Kokaji, and, despite challenging obstacles, the task is accomplished. Often, as in Kokaji, the accomplishment is due at least in part to the aid of a god, a very deus-ex-machina.
-</p><p>
-The task in Kokaji is the forging of a sword worthy of royal commission. The obstacle is the insistence, on the part of  the best sword smith in the land, Munechika, that he must have an equally skilled partner in order to hammer such a sword into perfection. There is no one the Munechika can call upon, so he prays to the god Inari. Then, rather abruptly, a mysterious figure (wearing the mask of a beautiful boy) calls out to him. In a session that is part coaching and part annunciation, the boy encourages Munechika to make preparations to forge the sword, doing so with recourse to Japanese proverbs and sententious Chinese verse.
-</p><p>
-In a long formal narrative (the kuri-sashi-kuse sequence), the boy recounts tales from both China and Japan, of illustrious swords. (No pressure!) Then, without more ado, he instructs Munechika to prepare the forge, both physically and ritually, only to disappear into the “evening clouds of Mt. Inari.” We can already surmise that this story is going to have a happy ending, but that doesn’t keep another actor, this time a kyôgen actor, from coming on stage as a minor local deity, to rehearse the plot once again.
-</p><p>
-So now to the accomplishment of the task: The plot is resolved in our minds, but the excitement of the play is really just getting off the ground, for now there is a sequence of musical pieces, some instrumental, some with chorus accompanied by the ensemble, during which the god Inari manifests himself to his human partner Munechika in forging the sword that is the focus of the miracle.  The god’s costume will be flashing metallic thread or appliqué, the mask will arrest our attention with a daemonic intensity, and above we will find a huge red wig crowned with a glittering circlet topped, in turn, with a shining image of a fox. This is what we came for, the appearance of a god, or demi-god at least.
-</p><p>
-The sequence of instrumental pieces that mark the last act of the play, the raijo, the hayafue and the maibataraki, is a tour-de-force, and marks off a special group of plays in the noh repertory as of particular excitement. These plays often bring a full day’s performance to an end. They are flashy and satisfyingly simple (to enjoy, if not to perform). They’ve been a staple of sarugaku performance since the late fourteenth-century and have their roots in the oldest identifiable traditions of the modern schools of noh.
-</p>
-<h3 id="plays-stars">* * * * *</h3>
-<p>
-With such archaic roots, miracle plays like Kokaji represent a kind of Ur-noh. They are discernible in the oldest traditions of the Yamato troupes that are the lineal ancestors of modern noh performance, and although Kokaji itself may not be that old, it is representative of an aesthetic of simple plots with definitive and felicitous conclusions. When we look back at Hashitomi from such a perspective, we are struck by now different it is, how the conclusion is anything but definitive — we don’t really know if the central character we’ve been watching for an hour or so is the exquisite ghost of the court of Genji or, rather, a transcendent manifestation of a gourd blossom.  She evaporates as if in a dream.
-</p><p>
-Her costume will be very beautiful, no doubt, and her mask perhaps virtuosically executed, but nonetheless generic. And on top of that, unlike Kokaji, with its two masks, Hashitomi requires only one. Viewers are likely as not going to be drawn to the fragile edifice of a gourd-flower arbor that is the main prop on stage in typical performances, as much as they are to the actors themselves. Or to an elaborate sculpture of blossoms that is then to be situated center stage— with the full acquiescence of the actors — for the entire first act of the play, when the play is performed in that special variant rikka style. You might say that the visual aesthetic of the play is diffused, like the identity of the shite, over the entire stage. In this sense, Hashitomi is more a play for expert members of the audience, than is Kokaji. As we have seen, it was likely composed by an amateur, someone interested not just in noh, but also flower arranging, someone eager to show off his knowledge of poems from The Tale of Genji, perhaps an aficionado of linked verse with a taste for Chinese learning as well.
-</p><p>
-All these features of Hashitomi make it an excellent resource for investigating the value-added aesthetic of plays written to contrast with those about gods and demons from the old Yamato tradition. These newer plays are more complex thematically and formally more self-conscious than those. They were incubated in the aesthetic world of the early to mid- fifteenth century, and exhibit an interest in mystery and subtlety, often discussed using the term yûgen. Although the Yamato tradition of performance lives on in Hashitomi as well as in Kokaji, it is transformed by the influence of other approaches to performance associated with the area near Lake Biwa, closer to Kyoto than the Yamato troupes, as well as by the example of mature classic plays such as Izutsu and Matsukaze.
-</p><p>
-That these two plays bear the hallmarks of different aesthetic, geographical and ideological strains makes them a particularly instructive pair for study.
+      Hashitomi is a wig play and Kokaji is generally considered a demon play or “fifth-category play, but in some cases
+      it is considered a “fourth-category play.” The central figure in Kokaji is actually a god (or daemon) rather than
+      a demon proper, which may account for its occasional placement in the fourth category.</p>
+    <p>
+      For all these inconsistencies, though, the goban-date system has had a productive role in structuring occasions of
+      performance, dating back into the seventeenth century, if not earlier. But this was still not the earliest way of
+      categorizing the repertory of noh, or as it was known then, “sarugaku.” In the late fourteenth century, a somewhat
+      different typology existed, at least in the writings of Zeami (1363-1443), with gods, women, warriors and demons,
+      to be sure, but also the deranged (in most cases, women), priests, Chinese “types”, and “roles in which the main
+      character doesn’t wear a mask.” Perhaps that was simply the way this most prominent noh actor in all the history
+      of noh thought about categories of sarugaku performance. But even Zeami wasn’t fully committed to such a schema,
+      since he changed to a more abstract system of “Three Modes” (Old Man, Warrior, and Woman) in the latter decades of
+      his life. </p>
+    <p>
+      The choice of Hashitomi and Kokaji for this site* doesn’t slot neatly into either of the schemes outlined above,
+      but for all that, it provides an instructive perspective on all of them, with ties to the historical development
+      of sarugaku into noh as well. Before we can compare the plays in this context, though, we should look at them
+      individually, to highlight their particular characteristics, both typical and unusual. Neither play is mentioned
+      frequently or prominently in the historical record of noh, so much of our evidence must come internally, from the
+      plays themselves, but that is the best way to understand their structure and content anyway. </p>
+    <h3 id="plays-Hashitomi">Hashitomi (or Hajitomi)</h3>
+    <p>
+      As is often the case with noh, neither Hashitomi nor Kokaji can be confidently attributed to a particular author
+      or composer. One of the lists of the noh repertory compiled in the seventeenth-century claims that Zeami wrote
+      Hashitomi, but this is highly unlikely. The author named in other lists of roughly the same time claims the play
+      was written by one Naitô Saemon, or Naitô Tôzaemon, or Ninagawa; little is known about these figures apart from
+      similar references to the authorship of two other noh plays by the said Naitô, so perhaps he was the writer of
+      Hashitomi after all. But even if we cannot be fully confident in such an identification, the question of
+      authorship nonetheless affords us a good perspective on not only Hashitomi and its reception but, more broadly, on
+      the solidification of performance conventions in noh, inter-arts comparisons and what has been termed the
+      “folklore” of The Tale of Genji. </p>
+    <p>
+      The name Naitô Saemon or Tôzaemon itself suggests lineage in a military family, and is very different in character
+      from the names of professional noh actors we can identify from the fourteenth and fifteenth century. It is likely
+      that as a noh or sarugaku playwright, Naitô (or whoever composed Hashitomi) was a talented amateur, and the play
+      bears various marks of the amateur, not just this name, as we shall see. And we should say from the start that
+      “amateur” here is not to be taken negatively. </p>
+    <p>
+      If Hashitomi bears a number of hallmarks of amateur composition, this makes it even more amenable to the
+      identification of general characteristics of wig plays, even as it illustrates the historical development of noh
+      in the fifteenth century more clearly than some of the more celebrated and intricately constructed plays of
+      professionals like Zeami.</p>
+    <p>
+      The central character of Hashitomi, for instance, is not readily identifiable. She bears certain associations with
+      the famous Lady of the Evening Faces, Yûgao no Ue, in The Tale of Genji, but she could also be understood to be
+      the spirit of the so-called yûgao plant, a type of bottle gourd with a white blossom. Such a spread of
+      associations comes about primarily because of the choice of poems and other passages from Genji quoted, and
+      sometimes altered, in the play.
+      The quotations in question come from a variety of contexts in Genji. One is a sophisticated comparison between the
+      moon and a departing lover, figuring the lady who longs for him on his departure to the mountain horizon. Another
+      requests that pinks (or dianthus flowers) deign to cast a thought, in the form of a dewdrop, onto the stakes of a
+      dilapidated fence: this is an elaborate metaphor asking a highborn lord to look in upon his little daughter, even
+      though her now dead mother was of undistinguished rank. Both of these allude to important plot points early in the
+      narrative of Genji, in connection with the ill-fated Lady of the Evening Faces, but both need the context of the
+      tale itself to fill out the incidents in question. That, though, does not seem to be what the writer of Hashitomi
+      intended. And yet, he was not just a magpie, picking up a snatch of poem here and a snatch of poem there. He was
+      aiming for a different kind of sophisticated effect, if we are to judge from his use of a third poem taken from
+      Genji. This poem appears in the play at the most conspicuous place possible, right after the shite’s jonomai at
+      the play’s climax. Or, to be more precise, we should say that the poem sandwiches the dance, because the first
+      line of it (altered in an interesting way) comes before the dance and then, once the dance is finished, the full
+      poem is sung.
+      In Genji, too, the poem in question comes at a crucial place; there, it serves as the pivot from simple curiosity
+      to a fatal romantic encounter. The poem reads:
+    </p>
+    <p>
+      <em>Yorite koso sore ka to mo mime tasokare ni</em><br>
+      <em>honobono mitsuru hana no yûgao </em><br>
+      Who is it, in the deepening dusk?<br>
+      Only by going up close might you see just who —<br>
+      the white gourd blossom <br>
+      fading out of view.
+    </p>
+    <p>
+      In Genji, this poem comes in response to another poem, on a slip of paper attached to a real yûgao blossom:</p>
+    <p>
+      <em>Kokoro-ate ni sore ka to zo miru shiratsuyu no</em><br>
+      <em>hikari soetaru yûgao no hana</em><br>
+      Venturing a guess, <br>
+      it looks to me just like “the very one”:<br>
+      light suffuses the white dewdrops<br>
+      on the blossoms of white gourd.<br>
+    </p>
+    <p>
+      This episode in Genji is one of its most characteristic, pairing an elite teenage male, a player in the erotic
+      competition of the classical romance, with a beauty bereft of the political and social connections needed to
+      maintain her position, any position, in the society of the novel. The initial vector for contact is classical
+      poetry, ostensibly about flowers, and these two poems allow the two lovers-to-be to break the ice and thus to
+      further the plot of the novel. The hidden female speaker of kokoro-ate ni is hinting that she understands it is
+      the Shining Prince, Genji himself that passes by her cottage, with its yûgao flowers, and Genji, in his response,
+      begs an invitation to get a closer look.
+    </p>
+    <p>
+      The poems also draw on a broader cultural matrix, that of an idealized classical culture of the royal court. In
+      addition to the figural use of the gourd blossom, which links the Lady of the Evening Faces with Genji, the
+      cultural associations of the flower, as codified and thematized in the practice of court poetry, create a rich
+      world of associations. They also set this world in soft focus, by ambiguity and interpretive polyvalency. The word
+      tasogare, “dusk”, for instance, provides the mise-en-scène for the gourd to blossom — it blooms at nightfall, and
+      each blossom perdures for but a single night. This foreshadows the brevity of a tragically brief love affair at
+      its very inception. It also impresses the time with an emotional character: if tasogare is dusk, it is the time
+      when one begins to fail to recognize passers-by. Indeed, ta so gare (or kare)” in ancient Japanese means “Who is
+      that?”
+    </p>
+    <p>
+      This grounding of the poem is used to specific ends in the novel, but when we consider the use of this and other
+      poems from the classical tradition in Hashitomi, we find that those are not necessarily the same ends.
+    </p>
+    <p>
+      There is, for instance, a crucial single-syllable change in the way the play quotes the Genji verse. Instead of
+      yorite koso, “Only by going up close”, the play reads orite koso, which means “only by breaking/snapping off”.
+      That could probably be construed to mean “take someone captive, romantically (or abusively),” but it is much more
+      prominently a word used of gathering sprigs or branches of flowers in bloom. This interpretation fits easily into
+      the general aesthetic context of Hashitomi, which is occasioned, according to the words of the waki in the
+      beginning of the play, by a Buddhist service propitiating the flowers that adorn ritual altars (the rikka kuyô).
+      With this reference, the play alludes to an intellectual debate popular in medieval Japan in which the boundaries
+      of sentiency, and thus, of the potential for enlightenment or salvation, were disputed. The debate is not fully
+      articulated in the play, but it’s clear enough that the composer felt plants and trees were sentient beings, and
+      deserving of reverence. In this, he was of the same opinion, apparently, as a number of other noh playwrights,
+      including the most celebrated.
+    </p>
+    <p>
+      With this, then, we begin to see Hashitomi in a somewhat broader context than merely that of an elegant tableau
+      vivant lifted from an old tale. It then reveals links not only to Buddhist thought about the natural world, but
+      also to an important inter-arts connection with the art of flower arranging.
+    </p>
+    <p>
+      This connection is, in fact, given material expression as the raison d’être for a variant performance style for
+      the play, in *all five modern schools. That variant style, or kogaki specifies a particular prop that is not used
+      in more conventional performances. The prop is a very large, very formal flower arrangement in an ancient style
+      called rikka or “standing flowers”, quoted directly from Buddhist antecedents. This arrangement is stationed
+      center-stage for the first part of the play when it is performed according to this variant, and it adds a
+      beautiful and conspicuous supplement to the already heavily floral character of the play.
+    </p>
+    <p>
+      There isn’t a clear documentary trail that would tell us when the play was first done in this manner, but in that
+      it straddles the worlds of noh performance and flower arranging, it points to the aesthetic cultivation of a time
+      when amateurs could compose noh plays, and have them performed, and integrate them with other overt expressions to
+      their cultural capital and inter-arts sophistication. And it is not merely in the context of noh and flower
+      arranging that we can see this in examining Hashitomi. In addition, we can reconsider the way the play deploys the
+      several classical Japanese poems it quotes. If they are not used to reimagine a scene from classic literature (as
+      other famous noh plays such as Izutsu or Atsumori do), they are nonetheless taken from self-conscious and serious
+      aesthetic aspirations. If the poems in question don’t all come from a particular narrative context in Genji, they
+      nonetheless share a common theme. The poem I mentioned earlier, about “the pinks . . . casting a thought, in the
+      form of a dewdrop, onto the stakes of a dilapidated fence,” though not from the “Lady of the Evening Faces”
+      episode in Genji, nonetheless comes from a foreshadowing of that episode in the previous chapter of the tale. It
+      seems very likely — and here we would follow Janet Goff in her fine study of noh based on Genji — that the
+      composer of Hashitomi might have discovered his thematic material for the play in the handbooks created for
+      practitioners of linked verse (many of them amateurs), where appropriate tags from classical poetry and narrative,
+      were collected and arranged topically for the use of latter-age versifiers.
+    </p>
+    <p>
+      One of the best known of those handbooks, Renju gappekishû, indeed, quotes the two poems from the encounter in
+      Genji with the same variant first line of the response poem, orite koso, that is cited in Hashitomi.
+    </p>
+    <p>
+      One sees a similar propensity to playing a game of poetic allusion in some of the Chinese verses quoted in
+      Hashitomi. Those verses come mostly from a collection of both Chinese and Japanese verse put together in the
+      eleventh century, Wakan rôeishû, and seem less successfully integrated into the play than the Genji verses. All
+      the same, they point to the same propensity for canvassing a broad inter-arts spectrum in order to compose the
+      play.
+    </p>
+    <p>
+      The title Hashitomi (or Hajitomi) has not been the exclusive title of this play in such documentation as exists
+      since the *seventeenth century. It has occasionally been known as Yûgao or Yûgao no Ue, provoking some confusion
+      because there is another play of the same name in the repertory. Modern scholarly consensus has distinguished the
+      two plays, leaving the other with the name Yûgao, pointing as well to the latter play’s more consistent and
+      narrative-oriented use of source poems from The Tale of Genji. For this reason, the possibility has been mooted
+      that that play was created by Zeami or at least by someone faithful to the guidelines he articulated.
+    </p>
+    <p>
+      That said, though, one can still identify in Hashitomi many of those same guidelines: the use of familiar poems
+      from old classics is itself something Zeami recommended, and the focus on dance, with the fully orthodox jonomai
+      of the final act sandwiched between lines from the central poem in the play is a common feature of many of the
+      classic plays in the repertory. (And although the professional actors and playwrights of the fifteenth century
+      cannot be directly credited with the jonomai, they do seem to have deployed its ancestor, the tennyo no mai as
+      early as the 1420s.*)
+    </p>
+    <p>
+      From this perspective, Hashitomi differs considerably from Kokaji. Although we have even less information on who
+      composed Kokaji than Hashitomi, and although we have no documentary evidence to show that it is an old play (of,
+      say, the late fourteenth or early fifteenth century). It nonetheless represents an older approach to noh, or
+      sarugaku performance, than Hashitomi, in that it is a miracle play: the claims of sarugaku tradition hold that it
+      originated in the miraculous manifestation of a native deity at the foot of a pine tree, the Pine of Divine
+      Revelation (yôgô no matsu) in the ancient capital Nara. Many of the oldest plays in the repertory show features of
+      this legend. Some of them are classed as god plays according to the goban-date system I mentioned at the beginning
+      of this essay. Others, though, often more interesting, are plays such as Kokaji, which fall into the final
+      category, the so-called “demon” plays. The shite in Kokaji, however, is no demon, but rather the god Inari Myôjin,
+      whose avatar is a fox.
+    </p>
+    <h3 id="plays-Kokaji">Kokaji</h3>
+    <p>
+      Something that often distinguishes “god plays” from “demon plays” in the five-genre system is interest. A few of
+      the god plays are wonderful, but many others are rigidly formal and austere (not to say boring). The “demon plays”
+      are never boring, and that is in part because of a plot. It’s not a complicated multi-layered plot usually, but
+      there is a “completion of action” in such a plot: a task is set, as in Kokaji, and, despite challenging obstacles,
+      the task is accomplished. Often, as in Kokaji, the accomplishment is due at least in part to the aid of a god, a
+      very deus-ex-machina.
+    </p>
+    <p>
+      The task in Kokaji is the forging of a sword worthy of royal commission. The obstacle is the insistence, on the
+      part of the best sword smith in the land, Munechika, that he must have an equally skilled partner in order to
+      hammer such a sword into perfection. There is no one the Munechika can call upon, so he prays to the god Inari.
+      Then, rather abruptly, a mysterious figure (wearing the mask of a beautiful boy) calls out to him. In a session
+      that is part coaching and part annunciation, the boy encourages Munechika to make preparations to forge the sword,
+      doing so with recourse to Japanese proverbs and sententious Chinese verse.
+    </p>
+    <p>
+      In a long formal narrative (the kuri-sashi-kuse sequence), the boy recounts tales from both China and Japan, of
+      illustrious swords. (No pressure!) Then, without more ado, he instructs Munechika to prepare the forge, both
+      physically and ritually, only to disappear into the “evening clouds of Mt. Inari.” We can already surmise that
+      this story is going to have a happy ending, but that doesn’t keep another actor, this time a kyôgen actor, from
+      coming on stage as a minor local deity, to rehearse the plot once again.
+    </p>
+    <p>
+      So now to the accomplishment of the task: The plot is resolved in our minds, but the excitement of the play is
+      really just getting off the ground, for now there is a sequence of musical pieces, some instrumental, some with
+      chorus accompanied by the ensemble, during which the god Inari manifests himself to his human partner Munechika in
+      forging the sword that is the focus of the miracle. The god’s costume will be flashing metallic thread or
+      appliqué, the mask will arrest our attention with a daemonic intensity, and above we will find a huge red wig
+      crowned with a glittering circlet topped, in turn, with a shining image of a fox. This is what we came for, the
+      appearance of a god, or demi-god at least.
+    </p>
+    <p>
+      The sequence of instrumental pieces that mark the last act of the play, the raijo, the hayafue and the
+      maibataraki, is a tour-de-force, and marks off a special group of plays in the noh repertory as of particular
+      excitement. These plays often bring a full day’s performance to an end. They are flashy and satisfyingly simple
+      (to enjoy, if not to perform). They’ve been a staple of sarugaku performance since the late fourteenth-century and
+      have their roots in the oldest identifiable traditions of the modern schools of noh.
+    </p>
+    <h3 id="plays-stars">* * * * *</h3>
+    <p>
+      With such archaic roots, miracle plays like Kokaji represent a kind of Ur-noh. They are discernible in the oldest
+      traditions of the Yamato troupes that are the lineal ancestors of modern noh performance, and although Kokaji
+      itself may not be that old, it is representative of an aesthetic of simple plots with definitive and felicitous
+      conclusions. When we look back at Hashitomi from such a perspective, we are struck by now different it is, how the
+      conclusion is anything but definitive — we don’t really know if the central character we’ve been watching for an
+      hour or so is the exquisite ghost of the court of Genji or, rather, a transcendent manifestation of a gourd
+      blossom. She evaporates as if in a dream.
+    </p>
+    <p>
+      Her costume will be very beautiful, no doubt, and her mask perhaps virtuosically executed, but nonetheless
+      generic. And on top of that, unlike Kokaji, with its two masks, Hashitomi requires only one. Viewers are likely as
+      not going to be drawn to the fragile edifice of a gourd-flower arbor that is the main prop on stage in typical
+      performances, as much as they are to the actors themselves. Or to an elaborate sculpture of blossoms that is then
+      to be situated center stage— with the full acquiescence of the actors — for the entire first act of the play, when
+      the play is performed in that special variant rikka style. You might say that the visual aesthetic of the play is
+      diffused, like the identity of the shite, over the entire stage. In this sense, Hashitomi is more a play for
+      expert members of the audience, than is Kokaji. As we have seen, it was likely composed by an amateur, someone
+      interested not just in noh, but also flower arranging, someone eager to show off his knowledge of poems from The
+      Tale of Genji, perhaps an aficionado of linked verse with a taste for Chinese learning as well.
+    </p>
+    <p>
+      All these features of Hashitomi make it an excellent resource for investigating the value-added aesthetic of plays
+      written to contrast with those about gods and demons from the old Yamato tradition. These newer plays are more
+      complex thematically and formally more self-conscious than those. They were incubated in the aesthetic world of
+      the early to mid- fifteenth century, and exhibit an interest in mystery and subtlety, often discussed using the
+      term yûgen. Although the Yamato tradition of performance lives on in Hashitomi as well as in Kokaji, it is
+      transformed by the influence of other approaches to performance associated with the area near Lake Biwa, closer to
+      Kyoto than the Yamato troupes, as well as by the example of mature classic plays such as Izutsu and Matsukaze.
+    </p>
+    <p>
+      That these two plays bear the hallmarks of different aesthetic, geographical and ideological strains makes them a
+      particularly instructive pair for study.
 
-</p>
-<p id="plays-footnotes">  1. The play Shunzei Tadanori, which remains in the noh repertory, as well as the play Kodama Ukifune, which has fallen out of performance, have been attributed to Naitô.  (Goff, p. 186.)
-</p><p>
-  2. Yama no ha no kokoro mo shirade yuku tsuki wa uwa no sora nite kage ya taenan
-Will the moon go off into the sky and fade from sight, all unawares of the longing heart at the mountain’s edge?
-</p><p>
-3. Yamagatsu no kakiho aru to mo oriori ni aware wa kakeyo nadeshiko no tsuyu
-Though the stakes in this rustic fence are bent this way and that
-from time to time, allow your thoughts to settle down upon it, dewdrops on the pinks</p><p>
+    </p>
+    <p id="plays-footnotes"> 1. The play Shunzei Tadanori, which remains in the noh repertory, as well as the play
+      Kodama Ukifune, which has fallen out of performance, have been attributed to Naitô. (Goff, p. 186.)
+    </p>
+    <p>
+      2. Yama no ha no kokoro mo shirade yuku tsuki wa uwa no sora nite kage ya taenan
+      Will the moon go off into the sky and fade from sight, all unawares of the longing heart at the mountain’s edge?
+    </p>
+    <p>
+      3. Yamagatsu no kakiho aru to mo oriori ni aware wa kakeyo nadeshiko no tsuyu
+      Though the stakes in this rustic fence are bent this way and that
+      from time to time, allow your thoughts to settle down upon it, dewdrops on the pinks</p>
+    <p>
 
-4.There is another variation in the noh play from the poem as quoted in Genji. This one is less significant in that it merely changes honobono mitsuru to honobono mieshi. I translated the former version “fading out of view”, but a more explicit version would be something like “which one saw vaguely.” Honobono mieshi has less explicit agency, and could be rendered, “which appeared vaguely.”
-</p>
+      4.There is another variation in the noh play from the poem as quoted in Genji. This one is less significant in
+      that it merely changes honobono mitsuru to honobono mieshi. I translated the former version “fading out of view”,
+      but a more explicit version would be something like “which one saw vaguely.” Honobono mieshi has less explicit
+      agency, and could be rendered, “which appeared vaguely.”
+    </p>
   </div>
 
 

--- a/src/text.html
+++ b/src/text.html
@@ -8,150 +8,70 @@ permalink: /text/
 
 {% include second-menu-elements.html %}
 
-{% include menu-text-large.html %}
-
 <main class="page-content">
-
-  <div class="wrapper sidebar-contents">
-    <aside class="sidebar-contents__table">
-      {% include menu-text.html %}
-    </aside>
-    <section class="sidebar-contents__section">
   <div class="text-container">
-  <h2>Text</h2>
-<p>The texts of Noh plays typically combine dialogue, inner thoughts, expression of feelings, memories, historic accounts and poetic references. As such, the Noh text is an amalgam of multiple literary genres that serve specific expressive needs.</p>
+    {% include menu-text-large.html %}
+    <div class="wrapper sidebar-contents">
 
-<p>Based on linguistic and literary characteristics the language of Noh falls under two categories: poetry (<em>inbun</em>) and prose (<em>sanbun</em>).</p>
+      <aside class="sidebar-contents__table">
+        {% include menu-text.html %}
+      </aside>
+      <section class="sidebar-contents__section">
+        <div class="text-container">
+          <h2>Text</h2>
+          <p>The text in Noh is free from strict logic of narrative progression. The plays typically focus on one
+            principal character and intermix actions and dialogue in the play's present with inner thoughts, feelings,
+            memories, historic accounts and poetic references. As such, the Noh text is an amalgam of multiple genres
+            and levels of formality that serve specific expressive needs.</p>
 
-
-  <h3 id="Poetry">Poetry</h3>
-
-<p> Noh prosody typically follows the rules of Japanese traditional poetry, which is based upon sequences of lines with a set number of Japanese syllables. The most common is the alternation of lines of seven and five but lines of other syllable lengths are also used. In Noh, the poetic language can be rhythmic or arhythmic. </p>
-
-<p>Rhythmic language organizes syllables into lines. It can use regular syllabic patterns of traditional poetry (<em>tei-ritsu bun</em>) or form irregular patterns (<em>ha-ritsu bun</em>).</p>
-
-<h4 id="Rhythmic-R">Rhythmic Regular</h4>
-<p>In the case of regular syllabic patterns repetition of 7 + 5 syllables is the norm but both hemistiches allow a decrease or increase by one or two syllables. The first hemistich is typically longer than the second one. This is illustrated by an example from Hashitomi Ageuta-1 below, which increases the first hemistich from 7 to 8 in the last two lines.</p>
-
-  <table class="content-table"><tr class="content-table__row">
-
-                <td class="content-table__column">
-Go jo o a ta ri to + i u ga o no<br>
-Go jo o a ta ri to + i u ga o no<br>
-so ra me se shi ma ni + yu me to na ri<br>
-o mo ka ge ba ka ri + na ki a to no<br>
-ta te ba na no ka ge ni + ka ku re ke ri<br>
-ta te ba na no ka ge ni + ka ku re ke ri</td>
-<td class="content-table__column">
-7 + 5<br>
-7 + 5<br>
-7 + 5<br>
-7 + 5<br>
-8 + 5<br>
-8 + 5</td>
-</table>
+          <p>Based on linguistic and literary characteristics the language of Noh (<em>buntai</em>) falls under two
+            categories: poetry (<em>inbun</em>) and prose (<em>sanbun</em>).</p>
 
 
-<p><em>Shōdan</em> presented in the Catalog that typically use language with regular syllabic patterns (tei-ritsu bun) include:  <a href="/catalog-of-shodan/shidai-chant" target="_blank"><em>shidai</em>-chant </a>, <a href="/catalog-of-shodan/ageuta" target="_blank"><em>ageuta</em></a>, <a href="/catalog-of-shodan/sageuta" target="_blank"><em>sageuta</em></a>, and <a href="/catalog-of-shodan/rongi" target="_blank"><em>rongi</em></a>.</p>
+          <h3 id="Poetry">Poetry</h3>
 
+          <p> Noh prosody typically follows the rules of Japanese traditional poetry, which is based upon sequences of
+            lines with a set number of syllables. The most common is the alternation of lines of five and seven but
+            lines of other syllable lengths are also used. In Noh, the poetic language can be rhythmic or arhythmic.
+          </p>
 
+          <p>Rhythmic language organizes syllables into lines. It can use regular syllabic patterns of traditional
+            poetry (<em>tei-ritsu bun</em>) or form irregular patterns (<em>ha-ritsu bun</em>). It must be noted that
+            when using regular patterns it is common in Noh to introduce exceptions to achieve specific dramatic effect.
+          </p>
+          <p>Common <em>shōdan</em> using language with regular syllabic patterns (<em>tei-ritsu bun</em>) include: <a
+              href="/catalog-of-shodan/shidai-chant" target="_blank"><em>shidai</em>-chant </a>, <a
+              href="/catalog-of-shodan/ageuta" target="_blank"><em>ageuta</em></a>, <a href="/catalog-of-shodan/sageuta"
+              target="_blank"><em>sageuta</em></a>, <a href="/catalog-of-shodan/rongi"
+              target="_blank"><em>rongi</em></a>, <a href="/catalog-of-shodan/issei-chant"
+              target="_blank"><em>issei</em>-chant</a>, and <a href="/catalog-of-shodan/kuri"
+              target="_blank"><em>kuri</em></a>.</p>
 
-<p>Within the same category of regular syllabic patterns is the waka style of poetry with its 5 + 7 + 5 + 7 + 7 syllables. An example of that is the <a href="/catalog-of-shodan/waka" target="_blank"><em>waka</em></a>.
+          <p>On the other hand, the <a href="/catalog-of-shodan/kuse" target="_blank"><em>kuse</em></a>, <a
+              href="/catalog-of-shodan/noriji" target="_blank"><em>noriji</em></a>, and <a
+              href="/catalog-of-shodan/kiri" target="_blank"><em>kiri</em></a> are common <em>shōdan</em> using language
+            with irregular syllabic patterns (<em>ha-ritsu bun</em>).</p>
 
-<h4 id="Rhythmic-I"> Rhythmic Irregular</h4>
-<p>7 + 5 remains the reference in irregular syllabic patterns, but the extent of fluctuation in the duration of hemistiches increases dramatically. The balance between the two hemistiches can even be reversed, thus the first hemistich becomes shorter than the second one. The following figure shows the possible combinations of numbers of syllables for the two hemistiches:
-  </p>
-  <table class="content-table">
-    <tr class="content-table__row">
+          <p>Arhythmic poetic language (<em>mu-ritsu inbun</em>), although not arranged as a succession of lines, is
+            still considered as poetic due to its use of devices found in Japanese poetry.</p>
+          <p>
+            The <a href="/catalog-of-shodan/sashi" target="_blank"><em>sashi</em></a> and <a
+              href="/catalog-of-shodan/mondo" target="_blank"><em>mondō</em></a> are good examples of <em>shōdan</em>
+            using language with arhythmic poetic language (<em>mu-ritsu inbun</em>).</p>
 
-    <td class="content-table__column"><h5>Hemistich 1</h5></td>
-    <td class="content-table__column"></td>
-      <td class="content-table__column"><h5>Hemistich 2</h5></td>
+          <h3 id="Prose">Prose</h3>
 
-    </tr>
-    <tr class="content-table__row">
-    <td class="content-table__column">
-    8<br><strong>7</strong><br>6<br>5<br>4<br>3<br>2
+          <p>During the medieval period, two different styles of prose were used: <em>nari-chō sanbun</em> characterized
+            by the use of <em>nari</em> as the ending of the verbs and its colloquial equivalent <em>sōrō-chō
+              sanbun</em>, which used <em>sōrō</em>. The two styles can be used in Noh to show the social rank of the
+            character but also to differentiate between a spirit and an earthly person. Moreover, the dramatic tension
+            of a text is often increased with a gradual change from <em>sōrō</em> to <em>nari</em>.</p>
 
-    </td>
-
-<td class="content-table__column">
-                  <br><br><br><strong>+</strong><br><br><br>
-</td>
-
-<td class="content-table__column">
-8<br>7<br>6<br><strong>5</strong><br>4<br>3
-
-</td>
-</tr>
-</table>
-<p>The following excerpt from Hashitomi Kuse is an example of irregular syllabic patterns (ha-ritsu bun):</p>
-
-
-<table class="content-table"><tr class="content-table__row">
-
-              <td class="content-table__column">
-so no ko ro + ge n ji no <br>
-chi u jo o to + ki ko e shi wa <br>
-ko no i u ga o no + ku sa ma ku ra <br>
-ta da ka ri bu shi no + yo mo su ga ra  <br>
-to na ri wo ki ke ba + mi yo shi no ya<br>
-mi ta ke sho o ji no + mi ko e ni te <br>
-na mu to o ra i + do o shi <br>
-mi ro ku bu tsu to zo + to na e ke ru <br>
-mi ro ku bu tsu to zo + to na e ke ru <br>
-so no to ki no o mo i + i de ra re te
-</td>
-<td class="content-table__column">
-  4 + 4<br>5 + 5<br>7 + 5<br>7 + 5<br>
-7 + 5<br>
-7 + 5<br>
-6 + 3<br>
-7 + 5<br>
-7 + 5<br>
-8 + 5</td>
-</table>
-
-<p>When text is set in ōnori, the standard number of syllables of the two hemistiches consists of shorter groups ranging from 2 to 6. It is common for the first and second hemistich to be 4 syllables long. Most lines in ōnori chants are rhythmically irregular. Here is the example from Kokaji's Noriji-1:</p>
-
-<table class="content-table"><tr class="content-table__row">
-
-              <td class="content-table__column">
-Ne ga wa + ku wa <br>
-Mu ne chi ka + wa ta ku shi no <br>
-Ko o myo o ni + a ra zu <br>
-Fu te n + so o to no  <br>
-Cho ku me i ni + yo re ri<br>
-Sa a ra ba + ji i po o <br>
-Go o sha no + sho ji n <br>
-Ta da i ma no + mu ne chi ka ni <br>
-Chi ka ra wo + a wa se te <br>
-Ta bi ta ma + e to te
-</td>
-<td class="content-table__column">
-  3 + 2<br>4 + 5<br>5 + 3<br>3 + 4<br>
-5 + 3<br>
-4 + 4<br>
-4 + 3<br>
-5 + 5<br>
-4 + 4<br>
-4 + 3</td>
-</table>
-
-
-  <p><em>Shōdan</em> found in the Catalogue that use language with irregular syllabic patterns (<em>ha-ritsu bun</em>) include:      <a href="/catalog-of-shodan/kuse" target="_blank"><em>kuse</em></a>, <a href="/catalog-of-shodan/noriji" target="_blank"><em>noriji</em></a> and <a href="/catalog-of-shodan/kiri" target="_blank"><em>kiri</em></a>.</p>
-
-<h4 id="Arhythmic"> Arhythmic</h4>
-<p>Arhythmic poetic language (<em>mu-ritsu inbun</em>), is not based on a perceivable division of line into hemistiches. Examples in the Catalogue include <a href="/catalog-of-shodan/sashi" target="_blank"><em>sashi</em></a> and <a href="/catalog-of-shodan/kuri" target="_blank"><em>kuri</em></a>. Issei-chant generally uses regular rhythmic language, however since <a href="/hashitomi/issei/" target="_blank">Hashitomi's Issei</a> is based on a Chinese poem it exceptionally uses arhythmic poetic language as well.</p>
-
-  <h3 id="Prose">Prose</h3>
-
-  <p>During the medieval period, two different styles of prose were used: <em>nari-chō sanbun</em> characterized by the use of <em>nari</em> as the ending of the verbs and <em>sōrō-chō sanbun</em>, which used <em>sōrō</em>. The two styles can be fluidely mixed in Noh.</p>
-
-  <p>In our shōdan catalogue, <a href="/catalog-of-shodan/mondo" target="_blank"><em>mondo</em></a>, <a href="/catalog-of-shodan/nanori" target="_blank"><em>nanori</em></a> and <a href="/catalog-of-shodan/kakeai" target="_blank"><em>kakeai</em></a> are examples of prose. In these examples, you can find <em>nari</em> style and <em>sōrō</em> style used interchangeably.  <em>Sōrō</em> style tends to be used when a character addresses others, while <em>nari</em> style is more typical for description and narration. The switching is also frequently found in <a href="/catalog-of-shodan/ai-kyogen" target="_blank"><em>ai-kyōgen</em></a>.</p>
-
-
-  </div>
-  </section>
+          <p>A common <em>shōdan</em> using prose in <em>nari-chō sanbun</em> style is the <em>katari</em>, whereas the
+            <a href="/catalog-of-shodan/nanori" target="_blank"><em>nanori</em></a> is a good example of a
+            <em>shōdan</em> using prose in <em>sōrō-chō sanbun</em> style.</p>
+        </div>
+      </section>
+    </div>
   </div>
 </main>


### PR DESCRIPTION
This is intended to close #321 regarding the excessive space at the top of the catalog pages, but the implementation has a knock-on effect of tightening up the spacing at the top of all of the static pages -- though some direct modification of the first-level static page templates was necessary to achieve a unified look. The updates seem to have met with general approval.
Note that the modification of the jump-scroll target in `filters.js` is a stopgap fix until issue #469 is addressed.