### PR TITLE
Work-around for Chrome issue.

### DIFF
--- a/src/_sass/layouts/_video-player.scss
+++ b/src/_sass/layouts/_video-player.scss
@@ -29,11 +29,15 @@
 }
 
 .sidebar__container {
+  display: flex;
   flex-grow: 1;
   overflow: hidden;
   position: relative;
 
-  @include flex-container($direction:column);
+  .react-tabs {
+    min-height: 0;
+    height: 100%;
+  }
 
   &::after {
     background-image: linear-gradient(rgba($white, 0) 0%, rgba($white, 1) 100%);

--- a/webpack/__tests__/__snapshots__/play.spec.jsx.snap
+++ b/webpack/__tests__/__snapshots__/play.spec.jsx.snap
@@ -1554,16 +1554,16 @@ exports[`<Play> renders as expected 1`] = `
                               noHtml={false}
                               noHtmlExceptMatchers={false}
                               parsedContent={null}
-                              tagName="span"
+                              tagName="div"
                             >
                               <Element
                                 attributes={Object {}}
                                 className=""
                                 commonClass="interweave"
                                 selfClose={false}
-                                tagName="span"
+                                tagName="div"
                               >
-                                <span
+                                <div
                                   className="interweave"
                                 >
                                   <Element
@@ -1771,7 +1771,7 @@ exports[`<Play> renders as expected 1`] = `
 
                                     </section>
                                   </Element>
-                                </span>
+                                </div>
                               </Element>
                             </Markup>
                           </div>

--- a/webpack/components/TabbedNarrative.jsx
+++ b/webpack/components/TabbedNarrative.jsx
@@ -51,7 +51,7 @@ class TabbedNarrative extends React.Component {
     ));
     const narrativeTabs = this.state.chunks.map(chunk => (
       <TabPanel key={chunk}>
-        <Markup content={chunk} />
+        <Markup tagName="div" content={chunk} />
       </TabPanel>
     ));
     return (


### PR DESCRIPTION
Fixes #462.

I'm pretty sure it's this one: https://bugs.chromium.org/p/chromium/issues/detail?id=927066

I hesitate to call it an outright bug, but it's certainly an implementation difference from all other browsers (it's probably a bug).

The fix/work-around is fine, and doesn't require any Javascript layout thrashing, which I had expected and feared would be the case.  In our case the issue was compounded by the fact that the `<Markup>` component we're using from the `interweave` package was rendering `<span>` elements (despite the documentation clearly stating that it defaults to `<div>` elements) which we were populating with block-level `<section>` elements and so on.