### PR TITLE
Add opaque wrapper to tab headers

### DIFF
--- a/src/_sass/components/videoplayer/_narrative-tabs.scss
+++ b/src/_sass/components/videoplayer/_narrative-tabs.scss
@@ -1,13 +1,23 @@
-.react-tabs {}
-  
 .react-tabs__tab-list {
   border-bottom-color: rgba($score_blue-light, 0);
   border-bottom-style: solid;
   border-bottom-width: 0.0625rem;
   margin: 0;
   padding: 0 1rem;
+  z-index: 1;
 
   @include flex-container($justify:flex-start, $align:stretch);
+}
+
+.react-tabs__tab-list::before {
+  background-color: white;
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: -1;
 }
 
 .react-tabs__tab  {


### PR DESCRIPTION
This should fix a minor issue that has been bothering me for a while. Previously, if the viewer height is fairly constrained and both the Shōdan map and Text accordions in the L2 sidebar are expanded, the label and divider graphic for the Text section would be drawn partially over and in the margins of the tab headers. This scenario requires a viewer height that is at one extreme of what we support, but it's not out of the question (i.e., the rest of the site still looks OK at those dimensions). Anyway, this fix adds an opaque pseudo-element behind the headers so that the overlap isn't visible.