### PR TITLE
Bump z-index of sidebar__extras

### DIFF
--- a/src/_sass/layouts/_video-player.scss
+++ b/src/_sass/layouts/_video-player.scss
@@ -80,6 +80,7 @@
 .sidebar__extras {
   flex-shrink: 0;
   width: 100%;
+  z-index: 1;
 
   h3 {
     cursor: pointer;


### PR DESCRIPTION
Replaces closed PR #487. This is the preferred solution, which just ensures that the "extra" sidebar accordions render entirely over the L2 sidebar tab headers when expanded in a short viewer window, rather than partially displaying behind them.