### PR TITLE
Set catalog pages to jump to 'catalog' anchor on checkbox de/select

### DIFF
--- a/src/assets/filters.js
+++ b/src/assets/filters.js
@@ -76,7 +76,7 @@ function attachFilters() {
         });
         // Avoid jump scrolling down to last (often invisible) card, while
         // ensuring the top row of cards isn't obscured by the sticky header
-        document.querySelector("div.filters__container").scrollIntoView();
+        document.getElementById("catalog").scrollIntoView();
       },
       false
     );

--- a/src/catalog-of-shodan.md
+++ b/src/catalog-of-shodan.md
@@ -13,9 +13,11 @@ permalink: /catalog-of-shodan/
   <div class="text-container">
     <h2>Catalog of Shōdan</h2>
     <p>
-The following partial catalog is limited to modules from the two plays featured in this website: Kokaji and Hashitomi. To prioritize information about musical characteristics the <em>shōdan</em> were recorded in a recital-style performance, and the videos are overlayed with simplified notation. </p>
+      The following partial catalog is limited to modules from the two plays featured in this website: Kokaji and
+      Hashitomi. To prioritize information about musical characteristics the <em>shōdan</em> were recorded in a
+      recital-style performance, and the videos are overlayed with simplified notation. </p>
   </div>
-<p id="catalog"></p>
+  <a id="catalog"></a>
   {% include filters.html catalog=site.data.catalog-sections images="shodan" %}
 
 </main>

--- a/src/movement.md
+++ b/src/movement.md
@@ -13,6 +13,7 @@ permalink: /movement/
     <h2>Catalog of Kata</h2>
 
   </div>
+  <a id="catalog"></a>
   {% include filters.html catalog=site.data.catalog-movements images="movement" %}
 
 </main>


### PR DESCRIPTION
These changes make the catalog pages work properly with the fix from #490 and Firefox.