### PR TITLE
Nudge menu bar to left to accommodate About tab

### DIFF
--- a/src/_includes/header-content.html
+++ b/src/_includes/header-content.html
@@ -9,7 +9,7 @@
   </a>
 
 
-  <nav class="header__nav">
+  <nav class="header__nav {{include.header_type}}">
     <ul>
       <li class="dropdown-menu{% if page.menu-active == 'intermedia' or page.menu-active == 'intermedia' %} active{% endif %}">
         <a class="header__main-link dropdown-menu__trigger">Intermedia</a>

--- a/src/_includes/header.html
+++ b/src/_includes/header.html
@@ -1,9 +1,12 @@
+{% assign page_type = "header__video-page" %}
+
 {% if layout.full-width-header == false %}
-<div class="wrapper">
+  {% assign page_type = "" %}
+  <div class="wrapper">
 {% endif %}
 
-  {% include header-content.html %}
+{% include header-content.html header_type=page_type %}
 
 {% if layout.full-width-header == false %}
-</div>
+  </div>
 {% endif %}

--- a/src/_sass/components/_header.scss
+++ b/src/_sass/components/_header.scss
@@ -38,6 +38,7 @@
 }
 
 .header__nav {
+
   > ul {
     @include flex-container();
 
@@ -52,6 +53,10 @@
       }
     }
   }
+}
+
+.header__video-page {
+  padding: 0 1.25rem 0 0;
 }
 
 .header__main-link {


### PR DESCRIPTION
This is a rudimentary fix for #483. It just moves the entire dropdown menu bar a bit to the left. There's some extra templating logic so that it only does this on L1 and L2 pages, because those are the only pages on which #483 is a problem.
Addressing #484, if desired, would require more changes.