### PR TITLE
Add fast-forward icon to video player time links

### DIFF
--- a/src/_sass/components/videoplayer/_narrative-text.scss
+++ b/src/_sass/components/videoplayer/_narrative-text.scss
@@ -42,6 +42,14 @@ section.interweave {
   time {
     text-decoration: underline;
     cursor: pointer;
+    &::before {
+      font-family: $font-icon;
+      font-size: x-small;
+      content: $fa-var-forward;
+      display: inline-block;
+      color: $brown40;
+      padding-left: .1rem;
+    }
   }
 }
 


### PR DESCRIPTION
This should implement the general consensus on how to style the indicators: just before the link, light gray (aka "$brown40"), not underlined. Note that a major find-and-replace sweep through the texts of the play narratives in `/src/_plays/narratives/` and the shōdan narratives in `/src/_hashitomi/narratives/` and `/src/_kokaji/narratives/` is still needed to remove or relocate extra spaces and occasional punctuation in the `<time>` links.