### PR TITLE
Red border around active shodan on L2

### DIFF
--- a/src/_sass/components/videoplayer/_timeline-shodan.scss
+++ b/src/_sass/components/videoplayer/_timeline-shodan.scss
@@ -96,13 +96,14 @@
     border: 0.0625rem solid $dan_8_edge;
   }
 
-  &.shodan-map__item--active {
-    background-color: $brown32;
-    border: 0.0625rem solid $brown32;
-  }
-
   &:hover {
     background-color: $dan_hover;
     border-color: $brown64;
   }
+
+  &.shodan-map__item--active {
+    border: 0.1250rem solid $red;
+    border-bottom-style: none;
+  }
+
 }


### PR DESCRIPTION
Re: issue #496, this implements the change discussed in yesterday's meeting: modifying the highlighting of the map element that represents the current shōdan in L2 from a gray fill to a thickened red border, so as not to obscure the 'dan' color-coding of the active shōdan. The hover highlight behavior on L2 as well as the L1 shōdan map remains unchanged (gray fill, darker border).