### PR TITLE
img template that can be scaled and left-aligned

### DIFF
--- a/src/_includes/image-scalable.html
+++ b/src/_includes/image-scalable.html
@@ -1,0 +1,6 @@
+{% assign alignment = "image-center" %}
+{% if include.align == "left" %}
+  {% assign alignment = "image-left" %}
+{% endif %}
+
+<img class="scalable {{ alignment }}" src="{{ include.src }}" alt="{{ alignment }}" width="{{ include.scale }}" height="{{ include.scale }}"/>

--- a/src/_sass/layouts/_layout-commons.scss
+++ b/src/_sass/layouts/_layout-commons.scss
@@ -45,6 +45,7 @@
 
 .image-container--no-background,
 .video-website--no-background {
+  width: min-content;
   margin: 2rem 0;
   padding: 2rem 0;
 }

--- a/src/_sass/layouts/_page.scss
+++ b/src/_sass/layouts/_page.scss
@@ -86,6 +86,9 @@
     display: block;
     margin: 0 auto;
     max-width: $wrapper-media;
+  }
+
+  video {
     width: 100%;
   }
 
@@ -165,6 +168,12 @@
   ::marker {
     color: $brown;
     @include text(md,'text');
+  }
+}
+
+img.scalable {
+  &.image-left {
+    display: inline;
   }
 }
 


### PR DESCRIPTION
Super simple template, not necessarily any more convenient than just typing in the `<img>` element, but it does have the benefit of being abstracted. Requested in #499 as a feature that probably will be used on the Guide page.