### PR TITLE
scalable image improvements

### DIFF
--- a/src/_includes/image-scalable.html
+++ b/src/_includes/image-scalable.html
@@ -3,4 +3,13 @@
   {% assign alignment = "image-left" %}
 {% endif %}
 
-<img class="scalable {{ alignment }}" src="{{ include.src }}" alt="{{ alignment }}" width="{{ include.scale }}" height="{{ include.scale }}"/>
+{% assign wrapper_class = "wrapper-small" %}
+{% if include.column_size == "medium" %}
+  {% assign wrapper_class = "wrapper-medium" %}
+{% elsif include.column_size == "large" %}
+  {% assign wrapper_class = "wrapper-large" %}
+{% endif %}
+
+<div class="scalable {{ wrapper_class }}">
+  <img class="scalable {{ alignment }}" src="{{ include.src }}" alt="{{ alignment }}" width="{{ include.scale }}" height="{{ include.scale }}"/>
+</div>

--- a/src/_sass/layouts/_layout-commons.scss
+++ b/src/_sass/layouts/_layout-commons.scss
@@ -45,7 +45,7 @@
 
 .image-container--no-background,
 .video-website--no-background {
-  width: min-content;
+  width: 100%;
   margin: 2rem 0;
   padding: 2rem 0;
 }

--- a/src/_sass/layouts/_page.scss
+++ b/src/_sass/layouts/_page.scss
@@ -177,6 +177,22 @@ img.scalable {
   }
 }
 
+div.scalable {
+  margin-bottom: 1rem;
+  margin-left: auto;
+  margin-right: auto;
+
+  &.wrapper-small {
+    max-width: $wrapper-small;
+  }
+  &.wrapper-medium {
+    max-width: $wrapper-medium;
+  }
+  &.wrapper-large {
+    max-width: $wrapper-large;
+  }
+}
+
 #back-to-top {
   background-color: $green;
 }


### PR DESCRIPTION
Given how the content columns are set up on the site, it works better to place the image in a div so that the image can be left-justified to match the given content width if desired and also scaled relative to the width of the column.