### PR TITLE
Additional styles for extended content table customization

### DIFF
--- a/src/_sass/components/website/content-table.scss
+++ b/src/_sass/components/website/content-table.scss
@@ -11,6 +11,13 @@
   &:nth-child(2n+1) {
     background-color: rgba($beige-light,0.5);
   }
+
+  &.--beige {
+    background-color: rgba($beige-light,0.5);
+  }
+  &.--white {
+    background-color: $white;
+  }
 }
 
 .content-table__column {
@@ -22,6 +29,21 @@
 
   p {
     @include text(md, 'text');
+  }
+
+  &.--greentext {
+    color: $green;
+    font-weight: $fw-semibold;
+    vertical-align: middle;
+    @include text(xxs);
+    @include uppercase();
+  }
+
+  &.--beige {
+    background-color: rgba($beige-light,0.5);
+  }
+  &.--white {
+    background-color: $white;
   }
 }
 

--- a/src/_sass/components/website/content-table.scss
+++ b/src/_sass/components/website/content-table.scss
@@ -12,10 +12,10 @@
     background-color: rgba($beige-light,0.5);
   }
 
-  &.--beige {
+  &.beige {
     background-color: rgba($beige-light,0.5);
   }
-  &.--white {
+  &.white {
     background-color: $white;
   }
 }
@@ -31,7 +31,7 @@
     @include text(md, 'text');
   }
 
-  &.--greentext {
+  &.greentext {
     color: $green;
     font-weight: $fw-semibold;
     vertical-align: middle;
@@ -39,10 +39,10 @@
     @include uppercase();
   }
 
-  &.--beige {
+  &.beige {
     background-color: rgba($beige-light,0.5);
   }
-  &.--white {
+  &.white {
     background-color: $white;
   }
 }


### PR DESCRIPTION
These are the extra CSS styles needed to enable the table row and cell customizations requested in Jarek's email and mentioned in the comment to #499 -- namely, being able to specify the background color of a row or cell (choosing from our palette of beige or white) and to specify the font of a cell (regular serif or else the all-caps green sans font). All of the other requested customization options can be handled via attributes attached directly to the HTML, as explained on the wiki.