### PR TITLE
Force `.sidebar` to be full-width

### DIFF
--- a/src/_sass/layouts/_video-player.scss
+++ b/src/_sass/layouts/_video-player.scss
@@ -25,7 +25,7 @@
   width: 35%;
   height: $video-player-height;
 
-  @include flex-container($direction:column, $justify:flex-start, $align: flex-start);
+  @include flex-container($direction:column, $justify:flex-start, $align: stretch);
 }
 
 .sidebar__container {


### PR DESCRIPTION
If the content of narrative sections in the side bar is minimal, such that it doesn't stretch the container out to be full-width anyway, you can get this:

![image](https://user-images.githubusercontent.com/96218/64055486-9551f580-cb41-11e9-874e-11a7ca735062.png)

(try `/kokaji/dialogue/` unless you have the most recent `contents` merged in).

This is 1) likely to be a non-issue once more content is loaded in; and 2) probably less of an eye-sore with overlay-scrollbars, I assume, but probably still deserves a little fix.