### PR TITLE
Update footnote formatting + move footnotes to main content divs

### DIFF
--- a/src/_sass/layouts/_page.scss
+++ b/src/_sass/layouts/_page.scss
@@ -149,7 +149,7 @@
 }
 
 .footnotes {
-  margin: 0 auto 2rem;
+  margin: 2rem auto 2rem auto;
   max-width: 40rem;
   ol, ul {
     list-style: decimal;

--- a/src/about-intermedia.md
+++ b/src/about-intermedia.md
@@ -117,6 +117,10 @@ Recognizing the proper <em>kurai</em> helps the performers achieve a better leve
 <p>–––––––––––––––––––––––––––––</p>
 <p>Noh is an intermedia art form of great expressive coherence. It breaths Yin and Yang as if in a fractal design. Through the fluidity of intermedia materials it embraces the impermanence of things and people. The abstract quality of its forms invites the audiences to engage deeply and become part of a rich and unique intermedia experience of Noh. </p>
 
+<div markdown="1">
+* footnotes will be placed here
+{:footnotes}
+</div>
 
   </div>
 </section></div>

--- a/src/plays.md
+++ b/src/plays.md
@@ -134,6 +134,12 @@ All these features of <em>Hashitomi</em> make it an excellent resource for inves
 That these two plays bear the hallmarks of different aesthetic, geographical and ideological strains makes them a particularly instructive pair for study.
 
 </p>
+
+<div markdown="1">
+* footnotes will be placed here
+{:footnotes}
+</div>
+
   </div>
 
 </main>

--- a/src/text-hashitomi.md
+++ b/src/text-hashitomi.md
@@ -870,12 +870,15 @@ sono mama yume to zo nari ni keru. </em></td>
 before dawn breaks, to the dwelling of the 'evening face'", <br>
 she says, and again goes within the lattice shutter, <br>
 just so, becoming one with the dream.   </td> </tr>
+</table>
 
-        </table>
+<div markdown="1">
+* footnotes will be placed here (do not remove this line or indent this <div> element!)
+{:footnotes}
+</div>
         </div>
     </section>
   </div>
-
 </main>
 
 [^1]: Tanka by Sōjō Henjō (816-890) from the Imperial anthology of waka: Gosen-shū, compiled in 951.

--- a/src/text-kokaji.md
+++ b/src/text-kokaji.md
@@ -802,17 +802,17 @@ Once more he leaps upon the mass of clouds,<br>
 Again, more he leaps upon the mass of clouds,<br>
 and return to Higashiyama, the eastern mountains, the peak of Mt. Inari!</p></td>
 </tr>
+</table>
 
-        </table>
-
+<div markdown="1">
+* footnotes will be placed here (do not remove this line or indent this <div> element!)
+{:footnotes}
+</div>
         </div>
     </section>
-
-
-
   </div>
-
 </main>
+
 [^1]: It starts with a reference to Liu Bang (256 – 195 BC), the founding Emperor of the Han dynasty. It is said that shortly before dying he exclaimed that “wielding a three-foot sword, as a commoner I conquered the world.” It is followed by a reference to Yang Jian (541 – 604 AD) the first Emperor of the Sui Dynasty and his sword Kei who defeated the House of Chou.
 
 [^2]: The Emperor Huan Tsung (713 – 742 AD) dreamed about his late Minister Chung K’ei coming to his defense with a sword.


### PR DESCRIPTION
This should close #526. Space has been added above the footnote section via the CSS style, and the footnote sections have been moved to the main content div on all pages with footnotes (except the front page) via kramdown's little-known templating method for this. The wiki has been updated accordingly.

kramdown's footnote formatting is only run on files ending in .md. The content files for the site all contain a mix of markdown and HTML markup, so the question of whether the extension is .md or .html is mostly academic -- the only real consequence being that the HTML in .md files seems to be subject to greater scrutiny by the markdown parser, which is less permissive than most browsers.