### PR TITLE
Remove extra margin above table content on libretto pages

### DIFF
--- a/src/_sass/components/website/content-table.scss
+++ b/src/_sass/components/website/content-table.scss
@@ -5,6 +5,11 @@
   @extend .wrapper;
 }
 
+.content-table--libretto {
+  margin-top: 0;
+  @extend .content-table;
+}
+
 .content-table__row {
   border-bottom: $border;
 

--- a/src/text-hashitomi.md
+++ b/src/text-hashitomi.md
@@ -23,8 +23,7 @@ permalink: /text-hashitomi/
         <h2 id="Hashitomi">Hashitomi Text</h2>
         <p><em> Author unknown (possibly Naitō Saemon, or Naitō Tōzaemon, or Ninagawa)<br>Kongō School Version<br>Translated by Rebecca Teele Ogamo</em></p>
 
-
-        <table class="content-table">
+        <table class="content-table--libretto">
 
         <tr class="content-table__row--header">
         <td id="Act1" class="content-table__column"><H3>ACT 1</H3></td>

--- a/src/text-hashitomi.md
+++ b/src/text-hashitomi.md
@@ -522,7 +522,7 @@ and perform a memorial service for the flowers.</td>
   In due time then, I will expect you there.</td>
 
   </tr>
-   
+
                       <tr class="content-table__row"></tr>
                 <tr class="content-table__row">
                         <td class="content-table__column">

--- a/src/text-kokaji.md
+++ b/src/text-kokaji.md
@@ -24,7 +24,7 @@ permalink: /text-kokaji/
 
         <p><em>Author unknown<br>Kongō School Version<br>Translated by Rebecca Teele Ogamo</em></p>
 
-        <table class="content-table">
+        <table class="content-table--libretto">
 
         <tr class="content-table__row--header">
         <td id="Act1" class="content-table__column"><H3>ACT 1</H3></td>


### PR DESCRIPTION
This mostly fixes #529, which concerned the extra space above the "ACT 1" top table row. The change actually involves two pages (the Hashitomi and Kokaji texts) so it seemed prudent to define a sub-style.
Note however that this does not completely address the small bit of extra vertical space evident on the Hashitomi page but not the Kokaji page, which appears in the Firefox inspector as a `whitespace` element. Its presence may be related to the spurious line endings in the content pages (see https://github.com/sul-cidr/noh/commit/92d2bc17436ba68f818c78579c010d2cc18a1ca5), but it's not clear if that's really the case here.