### PR TITLE
Enable pop-out video links in narrative text

### DIFF
--- a/webpack/__tests__/__snapshots__/tabbednarrative.spec.jsx.snap
+++ b/webpack/__tests__/__snapshots__/tabbednarrative.spec.jsx.snap
@@ -40,12 +40,12 @@ exports[`<TabbedNarrative> renders as expected 1`] = `
   <TabPanel
     className="react-tabs__tab-panel"
     forceRender={false}
-    key="<section  class=\\"tabbed-narrative\\"><p>Lorem ipsum dolor sit amet.</p></section>"
+    key="<section  class=\\"tabbed-narrative\\"><p>Lorem ipsum dolor <a href=\\"#0\\" onclick=\\"window.open()\\">sit</a> amet.</p></section>"
     selectedClassName="react-tabs__tab-panel--selected"
   >
     <Markup
       allowAttributes={true}
-      content="<section  class=\\"tabbed-narrative\\"><p>Lorem ipsum dolor sit amet.</p></section>"
+      content="<section  class=\\"tabbed-narrative\\"><p>Lorem ipsum dolor <a href=\\"#0\\" _onclick=\\"window.open()\\">sit</a> amet.</p></section>"
       emptyContent={null}
       parsedContent={null}
       tagName="div"

--- a/webpack/__tests__/tabbednarrative.spec.jsx
+++ b/webpack/__tests__/tabbednarrative.spec.jsx
@@ -9,7 +9,7 @@ import TabbedNarrative, {
 
 describe("<TabbedNarrative>", () => {
   const tabbedAnalysis =
-    "<section title='section one with many words in title' class='tabbed-narrative'><p>Lorem ipsum dolor sit amet.</p></section><br /><section title='section two'><p>Different stuff</p></section>";
+    "<section title='section one with many words in title' class='tabbed-narrative'><p>Lorem ipsum dolor <a href='#0' onclick='window.open()'>sit</a> amet.</p></section><br /><section title='section two'><p>Different stuff</p></section>";
 
   it("renders as expected", () => {
     const component = shallow(
@@ -34,6 +34,7 @@ describe("<TabbedNarrative>", () => {
     );
     const tabN = component.find("TabbedNarrative");
     tabN.instance().handleDomRef(tabN.getDOMNode());
+    expect(tabN.getDOMNode().querySelectorAll("a[onclick]").length).toEqual(1);
   });
 
   it("ref handler runs with null input", () => {

--- a/webpack/components/TabbedNarrative.jsx
+++ b/webpack/components/TabbedNarrative.jsx
@@ -51,12 +51,11 @@ class TabbedNarrative extends React.Component {
       if (tabsRef !== null) {
         const appContainer = tabsRef.closest(".app-container");
         if (appContainer) hookupMouseovers(appContainer);
-        if (appContainer)
-          appContainer
-            .querySelectorAll("a[_onclick]")
-            .forEach(link =>
-              link.setAttribute("onclick", link.getAttribute("_onclick"))
-            );
+        tabsRef
+          .querySelectorAll("a[_onclick]")
+          .forEach(link =>
+            link.setAttribute("onclick", link.getAttribute("_onclick"))
+          );
         const { parentElement } = tabsRef;
         parentElement.scrollTop = 0;
       }
@@ -130,4 +129,7 @@ const mapStateToProps = state => ({
 });
 
 export const Unwrapped = TabbedNarrative;
-export default connect(mapStateToProps, mapDispatchToProps)(TabbedNarrative);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(TabbedNarrative);

--- a/webpack/components/TabbedNarrative.jsx
+++ b/webpack/components/TabbedNarrative.jsx
@@ -45,12 +45,18 @@ class TabbedNarrative extends React.Component {
     };
 
     /* This function is triggered on all tab changes, as well as some other
-    * events. It is used to scroll the visible tab panel to the top upon
-    * activation, if necessary. */
+     * events. It is used to scroll the visible tab panel to the top upon
+     * activation, if necessary. */
     this.handleDomRef = tabsRef => {
       if (tabsRef !== null) {
         const appContainer = tabsRef.closest(".app-container");
         if (appContainer) hookupMouseovers(appContainer);
+        if (appContainer)
+          appContainer
+            .querySelectorAll("a[_onclick]")
+            .forEach(link =>
+              link.setAttribute("onclick", link.getAttribute("_onclick"))
+            );
         const { parentElement } = tabsRef;
         parentElement.scrollTop = 0;
       }
@@ -86,7 +92,11 @@ class TabbedNarrative extends React.Component {
     ));
     const narrativeTabs = this.state.chunks.map(chunk => (
       <TabPanel key={chunk}>
-        <Markup tagName="div" allowAttributes content={chunk} />
+        <Markup
+          tagName="div"
+          allowAttributes
+          content={chunk.replace(/\bonclick=/g, "_onclick=")}
+        />
       </TabPanel>
     ));
     const { updateNarrativeTab } = this.props;
@@ -120,7 +130,4 @@ const mapStateToProps = state => ({
 });
 
 export const Unwrapped = TabbedNarrative;
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(TabbedNarrative);
+export default connect(mapStateToProps, mapDispatchToProps)(TabbedNarrative);


### PR DESCRIPTION
So it turns out that the interweave component was stripping `onclick` attributes (in spite of instruction to the contrary), so this PR obfuscates them and then fixes them again once they've been injected into the DOM.  This is not a terrific solution, but it seems preferable to the immediately available alternatives.  (The best solution, imo, would be to dispense with interweave altogether, but that's not really on the table.)

Closes #528 