### PR TITLE
Add more padding to the right of the header menu

### DIFF
--- a/src/_sass/components/_header.scss
+++ b/src/_sass/components/_header.scss
@@ -15,12 +15,12 @@
 
 .header__content {
   min-height: $header-small-height;
-  padding: 0 2.5rem 0 1.25rem;
+  padding: 0 4rem 0 1.25rem;
 
   @include flex-container();
 
   .wrapper & {
-    padding: 1rem 0;
+    padding: 1rem 2rem 1rem 0;
   }
 }
 


### PR DESCRIPTION
This is meant to close #546 by expanding the padding to the right of the menu in the template for L1/2, after the `Elements` drop-down.

The change to the `.wrapper` style applies a slightly smaller increase to the top menu on L0 so that the drop-down also doesn't exceed the edge of the window at 1024 pixels-wide screens, which is the expected width of the smallest screens/devices (e.g. a horizontal 1st or 2nd gen iPad) we intend to support for this project.