### PR TITLE
Footnote polishing

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -26,6 +26,7 @@ source: src
 markdown: kramdown
 kramdown:
   footnote_backlink_inline: true
+  footnote_backlink: '&#8617;&#65038;'
 # theme: minima
 
 # Collection settings

--- a/src/_sass/layouts/_page.scss
+++ b/src/_sass/layouts/_page.scss
@@ -154,6 +154,10 @@
   ol, ul {
     list-style: decimal;
   }
+  li {
+    font-family: "Source Serif Pro", Georgia, serif;
+    color: $brown;
+  }
   p {
     color: $brown;
     @include text(md,'text');


### PR DESCRIPTION
Color and font of footnote numbers now match text; footnote backlinks no longer turn into emojis on iOS and Android.