### PR TITLE
Disable click navigation for "🛈" buttons on videos

### DIFF
--- a/src/_includes/video-no-background.html
+++ b/src/_includes/video-no-background.html
@@ -1,17 +1,16 @@
 <div class="video-website--no-background">
   <div class="video-website__container">
-    {% if include.link %}
-      <a class="video-website__toggle" href="">
-        <strong>{{ include.link }}</strong>
-        <i class="fas fa-info-circle"></i>
-      </a>
-    {% endif %}
+
+      {% if include.link %}<strong>{{ include.link }}</strong>{% endif %}
+      <i class="fas fa-info-circle"></i>
+    </a>
+
     <div class="video-website__tooltip">
       <div class="video-website__description">
-        <h6>{{ include.title }}</h6>
-        <p>{{ include.paragraph1 }}</p>
-        <p>{{ include.paragraph2 }}</p>
-        <p>{{ include.paragraph3 }}</p>
+        {% if include.title %}<h6>{{ include.title }}</h6>{% endif %}
+        {% if include.paragraph1 %}<p>{{ include.paragraph1 }}</p>{% endif %}
+        {% if include.paragraph2 %}<p>{{ include.paragraph2 }}</p>{% endif %}
+        {% if include.paragraph3 %}<p>{{ include.paragraph3 }}</p>{% endif %}
       </div>
     </div>
     <video id="player" controls="" controlslist="nodownload">

--- a/src/_includes/video-no-background.html
+++ b/src/_includes/video-no-background.html
@@ -1,6 +1,7 @@
 <div class="video-website--no-background">
   <div class="video-website__container">
 
+    <a class="video-website__toggle" href="javascript:void(0)">
       {% if include.link %}<strong>{{ include.link }}</strong>{% endif %}
       <i class="fas fa-info-circle"></i>
     </a>

--- a/src/_music/voices.html
+++ b/src/_music/voices.html
@@ -1,38 +1,38 @@
----
-layout: website
-menu-active: elements
-second-level-menu-active: music
-third-level-menu-active: voices
-fourth-level-menu-active: voices
----
-
-{% include second-menu-elements.html %}
-
-{% include menu-instrument-small.html %}
-
-<main class="page-content">
-
-  <div class="wrapper sidebar-contents">
-    <aside class="sidebar-contents__table">
-      {% include menu-voices.html %}
-    </aside>
-    <section class="sidebar-contents__section">
-      <div class="text-container">
-        <h2 id="Sound">Vocal Sound</h2>
+---
+layout: website
+menu-active: elements
+second-level-menu-active: music
+third-level-menu-active: voices
+fourth-level-menu-active: voices
+---
+
+{% include second-menu-elements.html %}
+
+{% include menu-instrument-small.html %}
+
+<main class="page-content">
+
+  <div class="wrapper sidebar-contents">
+    <aside class="sidebar-contents__table">
+      {% include menu-voices.html %}
+    </aside>
+    <section class="sidebar-contents__section">
+      <div class="text-container">
+        <h2 id="Sound">Vocal Sound</h2>
         <p>The vocal production in Noh is highly stylized. It is based on diaphragmatic breathing that reverberates through the head, chest and oral cavity. It should project sufficient loudness even when the singer wears a mask.</p>
 
         <p>The vocal tone-center is relative. The first person who starts a chant instigates the central tone, and that tone range is informed by the character he is impersonating. The secondary actor signals his lower position by providing lighter, faster and higher tones (for example,  Wakizure in Kokaji). Larger width of the range indicates the protagonist is a man while a narrower range indicates a woman.</p>
 
-        <p>There are two general styles of <em>utai</em>: spoken and chanted. Both are intoned in full voice, but never in falsetto. </p>
+        <p>There are two general styles of <em>utai</em>: spoken and chanted. Both are intoned in full voice, but never in falsetto. </p>
 
-        <h3 id="Spoken">Spoken</h3>
-        <p>
+        <h3 id="Spoken">Spoken</h3>
+        <p>
         The spoken sections, called <em>kotoba</em>, consist of unmetered prose. Usually the recitation divides a sentence into two parts: a gradual rising tone reaching a peak followed by a falling off.  The highest tone falls on the second syllable of the second part. In the text transcription of the excerpts, syllables in bold identify the higher tones that lead to a descent.  </p>
-        <p>
+        <p>
         Sections in <em>kotoba</em> are always delivered by an actor or two, but never by the jiutai. When considering the dramatic unfolding of a play, the difference between the two is important. The text delivered in <em>kotoba</em> by a single actor tends to be factual, whereas spoken text between two actors usually carries information that furthers and nourishes the unfolding drama.</p>
 
         <p>
-        The difference in style between the shite's and waki's <em>kotoba</em> can be heard in the following three examples:</p>
+        The difference in style between the shite's and waki's <em>kotoba</em> can be heard in the following three examples:</p>
         <div class="tabs-container">
           <div class="tabs-container__links">
             <div class="wrapper">
@@ -92,65 +92,65 @@ fourth-level-menu-active: voices
             </div>
           </div>
         </div>
-
-            <h3 id="Chanted">Chanted</h3>
-            <p>
+
+            <h3 id="Chanted">Chanted</h3>
+            <p>
     The chanted music, called <em>utai</em>, can be sung in two different styles: <em>yowagin</em>, a gentler melodic singing, and <em>tsuyogin</em>, a more forceful and dramatic style.
-            </p>
-
-          <h4 id="Yowagin">Yowagin</h4>
-            <p>
+            </p>
+
+          <h4 id="Yowagin">Yowagin</h4>
+            <p>
           When singing in <em>yowagin</em> style, the actor uses a modest vibrato, producing melodies with perceptible stable tones. This style is common in passages expressing elegance and pathos.
-             </p><p>
+             </p><p>
             Even if the tonal center of a chant in Noh is not absolute and is instead determined by the performer, the chant’s intervals are fixed. The entire range covers two octaves and is divided into four register zones: Very Low, Low, Medium, and High, each one covering more or less the span of a perfect fourth.
-             </p><p>
-            Since tones are relative, they are referred to by a general name. The three most important tones are the Low, Medium, and High (in our example B2, E3, and A3 respectively), and the majority of the chants are set around these three nuclear-tones. Intermediate tones are used to melodically flow from one nuclear-tone to another.</p><p>
+             </p><p>
+            Since tones are relative, they are referred to by a general name. The three most important tones are the Low, Medium, and High (in our example B2, E3, and A3 respectively), and the majority of the chants are set around these three nuclear-tones. Intermediate tones are used to melodically flow from one nuclear-tone to another.</p><p>
 
             Finally, the lower and higher ranges are extended with the addition of the low <em>ryo</em> and the <em>ryo</em> (E2 and F#2 respectively) for the former, and the <em>kuri</em> and high <em>kuri</em> (C4 and E4 respectively) for that latter.
-
-            </p>
-            {% include image-no-background.html src="/assets/images/Yowagin-range.jpg" %}
-
-            {% include video-no-background.html
-            src="https://d7rcwrflqckpu.cloudfront.net/Academic_sl/Hagoromo-Kuri_yowagin_Range_sl.mp4"
-            link="Yowagin"
-            title="Hagoromo/Kuri"
+
+            </p>
+            {% include image-no-background.html src="/assets/images/Yowagin-range.jpg" %}
+
+            {% include video-no-background.html
+            src="https://d7rcwrflqckpu.cloudfront.net/Academic_sl/Hagoromo-Kuri_yowagin_Range_sl.mp4"
+            link="Yowagin"
+            title="Hagoromo/Kuri"
             paragraph1="The module is named after the <em>kuri </em> tone from the higher register. For the most part, the melodic material of the piece focuses on the High tone with few incursions on the <em>kuri</em>, shown in bold in the text of the video."
 
-            paragraph2="Upon reaching the <em>kuri</em>’s signature cadential melisma, the <em>hon-yuri</em>, the melodic material switches to Medium before cadencing on the Low. (The pitch material in this performance is a major second lower than the one shown in the figure above)."
-            paragraph3="The registers in the video are symbolized by the following letters: L (Low), M (Medium), H (High), K (Kuri)."%}
-
-
-
-          <h4 id="Tsuyogin">Tsuyogin</h4>
-
+            paragraph2="Upon reaching the <em>kuri</em>’s signature cadential melisma, the <em>hon-yuri</em>, the melodic material switches to Medium before cadencing on the Low. (The pitch material in this performance is a major second lower than the one shown in the figure above)."
+            paragraph3="The registers in the video are symbolized by the following letters: L (Low), M (Medium), H (High), K (Kuri)."%}
+
+
+
+          <h4 id="Tsuyogin">Tsuyogin</h4>
+
             <p>While singing in <em>tsuyogin</em> style, the actor uses a notable vibrato with utterances usually contained within a small range span. This style is used for most dramatic passages expressing events and emotions like celebration, excitement, bravery, or solemnity.
-     </p><p>
-    The actors do not attempt to produce specific melodic tones. Their singing oscillates mainly within a minor third shown below as Low and High tones. However, at specific moments the High tone is embellished with higher ones.
-    </p>
-
-            {% include image-no-background.html src="/assets/images/Tsuyoggin-range.png" %}
-      {% include video-no-background.html
-        src="https://d7rcwrflqckpu.cloudfront.net/Academic_sl/Kokaji-Kuri_tsuyogin_Range_sl.mp4"
-        link="Tsuyogin"
-        title="Kokaji/Kuri"
-        paragraph1="The section's name refers to the high tone <em>kuri</em>, so this section's melody is set in the higher register."
-        paragraph2="The registers in the video are symbolized by the following letters: L (Low), H (High), K (Kuri)."
-      %}
-
-
-        <h2 id="Rhythm"> Vocal Rhythm</h2>
-
-        <p> The vocal parts fall into two main categories of rhythm: congruent when their parts align with specific beats, and non-congruent when they do not.</p>
-
-        <h3 id="Congruent">Congruent (<em>hyōshi-ai</em>)</h3>
-        <p>A Noh chant is said to be congruent when its syllables coincide with the measure’s beats. There are three possible congruent settings: <a href="/music/voices#Hiranori" target="_blank"><em>hiranori</em></a>, <a href="/music/voices#Onori" target="_blank"><em>ōnori</em></a>, and <a href="/music/voices#Chunori" target="_blank"><em>chūnori</em></a>.</p>
-
-        <h4 id="Hiranori">Hiranori</h4>
-
-        <p>Verse consisting of alternating lines of seven and five syllables is the most lyrical and elegant form of Japanese poetry, as seen in haiku, waka, and renga, among other poetic forms. <em>Hiranori</em> is the basic rhythmic form used in Noh where the poetic twelve syllables match with the <em>honji</em>’s eight-beat. Considering that there is a possibility of two syllables per beat for a total of sixteen syllables per <em>honji</em>, this leaves space for four caesuras. The standard positions for the caesuras are on beats 1, 3, 5 and 8, dividing the <em>honji</em> in two asymmetric hemistichs: one of four beats and a half, the other one with three beats and a half.</p>
-
-        <p>The <em>hiranori</em> setting has two singing styles: <a href="/music/voices/#Tsuzuke-Utai" target="_blank"><em>tsuzuke-utai</em></a> and <a href="/music/voices/#Mitsuji-Utai" target="_blank"><em>mitsuji-utai</em></a>. The explanation of the two individual styles is followed by a <a href="/music/voices/#Demonstration" target="_blank">demonstration in context</a>, which shows how they can complement each other in a chant. The following examples are based on Hashitomi’s first <em>Ageuta</em>.</p>
+     </p><p>
+    The actors do not attempt to produce specific melodic tones. Their singing oscillates mainly within a minor third shown below as Low and High tones. However, at specific moments the High tone is embellished with higher ones.
+    </p>
+
+            {% include image-no-background.html src="/assets/images/Tsuyoggin-range.png" %}
+      {% include video-no-background.html
+        src="https://d7rcwrflqckpu.cloudfront.net/Academic_sl/Kokaji-Kuri_tsuyogin_Range_sl.mp4"
+        link="Tsuyogin"
+        title="Kokaji/Kuri"
+        paragraph1="The section's name refers to the high tone <em>kuri</em>, so this section's melody is set in the higher register."
+        paragraph2="The registers in the video are symbolized by the following letters: L (Low), H (High), K (Kuri)."
+      %}
+
+
+        <h2 id="Rhythm"> Vocal Rhythm</h2>
+
+        <p> The vocal parts fall into two main categories of rhythm: congruent when their parts align with specific beats, and non-congruent when they do not.</p>
+
+        <h3 id="Congruent">Congruent (<em>hyōshi-ai</em>)</h3>
+        <p>A Noh chant is said to be congruent when its syllables coincide with the measure’s beats. There are three possible congruent settings: <a href="/music/voices#Hiranori" target="_blank"><em>hiranori</em></a>, <a href="/music/voices#Onori" target="_blank"><em>ōnori</em></a>, and <a href="/music/voices#Chunori" target="_blank"><em>chūnori</em></a>.</p>
+
+        <h4 id="Hiranori">Hiranori</h4>
+
+        <p>Verse consisting of alternating lines of seven and five syllables is the most lyrical and elegant form of Japanese poetry, as seen in haiku, waka, and renga, among other poetic forms. <em>Hiranori</em> is the basic rhythmic form used in Noh where the poetic twelve syllables match with the <em>honji</em>’s eight-beat. Considering that there is a possibility of two syllables per beat for a total of sixteen syllables per <em>honji</em>, this leaves space for four caesuras. The standard positions for the caesuras are on beats 1, 3, 5 and 8, dividing the <em>honji</em> in two asymmetric hemistichs: one of four beats and a half, the other one with three beats and a half.</p>
+
+        <p>The <em>hiranori</em> setting has two singing styles: <a href="/music/voices/#Tsuzuke-Utai" target="_blank"><em>tsuzuke-utai</em></a> and <a href="/music/voices/#Mitsuji-Utai" target="_blank"><em>mitsuji-utai</em></a>. The explanation of the two individual styles is followed by a <a href="/music/voices/#Demonstration" target="_blank">demonstration in context</a>, which shows how they can complement each other in a chant. The following examples are based on Hashitomi’s first <em>Ageuta</em>.</p>
         <div class="tabs-container">
           <div class="tabs-container__links">
             <div class="wrapper">
@@ -268,98 +268,98 @@ fourth-level-menu-active: voices
           </div>
         </div>
 
-
-
 
-        <h4 id="Onori">Ōnori</h4>
-
-        <p>A text setting in <em>ōnori</em> has one syllable per beat. The first syllable of each line of text comes on the second or second beat-and-half. Because of its periodic quality, this text setting is often used before or after a dance or in the concluding module (<em>shōdan</em>) of a play, the <em>Kiri</em>.</p>
-
-        {% include image-no-background.html
-          src="/assets/images/Onori.png"
-        %}
-
-        {% include video-no-background.html
-          src="https://d7rcwrflqckpu.cloudfront.net/Academic_sl/Kokaji-Noriji2_Onori.mp4"
-          link="Ōnori"
-          title="Kokaji/Noriji 2"
-        %}
-
-        <h4 id="Chunori">Chūnori</h4>
-
-        <p>Text set in <em>chūnori</em> has two syllables per beat. The first syllable of each line of text typically comes on the first or first beat and a half, with a complete line finishing within the span of a single <em>honji</em>.</p>
-
-        <p>Because of its lively quality, this text setting is often used for description of an active moment, such as a battle. Although, it is common practice for a <em>shōdan</em> whose text is set to <em>chūnori</em> to also include passages set in <em>hiranori</em>, the eight-beat units (<em>honji</em>) is almost never contracted, like in <em>mitsuji-utai</em>, rather  it remains steady.</p>
-        {% include image-no-background.html
-          src="/assets/images/Chunori.png"
-        %}
-        {% include video-no-background.html
-          src="https://d7rcwrflqckpu.cloudfront.net/Academic_sl/Kokaji-Kiri_Chunori.mp4"
-          link="Chūnori"
-          title="Kokaji/Kiri"
-        %}
-
-        <h4 id="TextSetting">Text setting exceptions</h4>
-
-        <p> Occasionally, lines of text do not fit within the 7 + 5 model. The number of syllables for the first hemistich can vary between two and ten, and three and eight for the second one. There are two methods that allow for the rhythmic adjustment of syllables: the first one involves starting the line's first syllable on a different beat, whereas the second method involves the insertion of measures of various sizes.</p>
-
-        <p>The standard position for the first syllable of a line of text is on the upbeat leading to the <em>honji's</em> first downbeat. Thus, one method of fitting a larger than twelve syllables line of text within a <em>honji</em> consist of starting its first syllable earlier than the standard upbeat to the first beat. For example, the last line of text of Hashitomi’s first <em>Ageuta</em> is comprised of thirteen syllables: 8 + 5.</p>
-
-        {% include image-no-background.html
-          src="/assets/images/FirstMethod-Text.png"
-          %}
-
-        <p>In this case, ‘Ta,’ the first syllable, starts on the eighth downbeat as seen below instead of the usual upbeat to the very first beat:</p>
-
-        {% include image-no-background.html
-          src="/assets/images/FirstMethod-Rhythm.png"
-        %}
-
-        <p>The second method of setting lines of text that exceed twelve syllables consists of introducing measures of two (<em>okuriji</em>), four (<em>toriji</em>), or six (<em>kataji</em>) beats. For example, here are the first three lines of Kokaji’s <em>Kiri</em>. Its syllabic structure is: 7 + 5, 7 + 6, and 9 + 5.</p>
-
-        {% include image-no-background.html
-          src="/assets/images/2ndMethod-Text.png"
-        %}
-        <p> A <em>toriji</em> (measure of four beats) has been inserted between the second and third <em>honji</em> (eight beat unit) in order to counter-balance the odd syllabic structure of the text. When it comes to measures other than the <em>honji</em>, the <em>toriji</em> is far more common that the two- and six-beat measures.</p>
-        {% include image-no-background.html
-          src="/assets/images/2ndMethod-Rhythm.png"
-        %}
-
-        <h3 id="Non-congruent">Non-congruent (<em>hyōshi-awazu</em>)</h3>
-
-        <p>The emphasis for non-congruent chants is on the text and melodic line. With this text setting there is no coordination between syllables and the unit’s eight beats. There are two types of non-congruent chant: <em>sashinori</em> and <em>einori</em>.</p>
-
-        <p><em>Sashinori</em> chant is always accompanied by the ōtsuzumi and kotsuzumi in a flexible setting, while <em>einori</em> chant can be accompanied by the hand percussion instruments in either strict or flexible setting. If the chant includes a nohkan part it will also be non-congruent.</p>
-
-
-        <h4 id="Sashinori">Sashinori</h4>
-
-        <p><em>Sashinori</em> chants are sung in a recitative style, accompanied by the ōtsuzumi and kotsuzumi in flexible setting, favoring the sparse <em>mitsuji</em> patterns. On the other hand, the <em>Kuri</em> also accompanied by the two hand-drums in flexible setting, favors the <em>tsuzuke</em> pattern.  There is a Japanese expression that describes well the idea behind a non-congruent chant accompanied by percussions in flexible rhythmic setting: <em>fusoku furi</em> which means ‘not separate but not together’.</p>
-
-        <p>The <em>Sashi</em> from Kokaji, sung in <em>tsuyogin</em> mode, is composed of two parts. Each one begins by a solo performed the shite followed by a reply by the jiutai. The reply is broken up into melodic lines rhythmically characterized by a slightly accelerated pulse that becomes a sustained tone. The sustained tones are positioned on syllables that reinforce the text's structure or meaning. For the most part, each line stays on the high tone, usually preceded with an inflection from below. Finally, the chant concludes on the low tone.</p>
-
-        <p>The score provided for this excerpt shows the first part is composed of six lines, each concluded by a sustained tone: the shite presents the first, the jiutai the next five, identified in the score with the numbers 1 to 6. It is the two percussionists' responsibility to position their four <em>mitsuji</em> patterns against these six lines.</p>
-
-        {% include video-no-background.html
-          src="https://d7rcwrflqckpu.cloudfront.net/Academic_sl/Kokaji-Sahi_Sashinori.mp4"
-          link="Sashinori"
-          title="Kokaji/Sashi"
-        %}
-
-        <h4 id="Einori">Einori</h4>
-
-        <p> <em>Einori</em> chants are usually accompanied by the ōtsuzumi and kotsuzumi in strict setting. The <em>Issei-</em>chant from Hashitomi is sung in <em>yowagin</em> style, focusing on only four tones: the Medium and High, and their respective Intermediate tones a second lower. It is divided up into two segments: the first one sung by the shite, the second one by the jiutai.</p>
-
+
+
+        <h4 id="Onori">Ōnori</h4>
+
+        <p>A text setting in <em>ōnori</em> has one syllable per beat. The first syllable of each line of text comes on the second or second beat-and-half. Because of its periodic quality, this text setting is often used before or after a dance or in the concluding module (<em>shōdan</em>) of a play, the <em>Kiri</em>.</p>
+
+        {% include image-no-background.html
+          src="/assets/images/Onori.png"
+        %}
+
+        {% include video-no-background.html
+          src="https://d7rcwrflqckpu.cloudfront.net/Academic_sl/Kokaji-Noriji2_Onori.mp4"
+          link="Ōnori"
+          title="Kokaji/Noriji 2"
+        %}
+
+        <h4 id="Chunori">Chūnori</h4>
+
+        <p>Text set in <em>chūnori</em> has two syllables per beat. The first syllable of each line of text typically comes on the first or first beat and a half, with a complete line finishing within the span of a single <em>honji</em>.</p>
+
+        <p>Because of its lively quality, this text setting is often used for description of an active moment, such as a battle. Although, it is common practice for a <em>shōdan</em> whose text is set to <em>chūnori</em> to also include passages set in <em>hiranori</em>, the eight-beat units (<em>honji</em>) is almost never contracted, like in <em>mitsuji-utai</em>, rather  it remains steady.</p>
+        {% include image-no-background.html
+          src="/assets/images/Chunori.png"
+        %}
+        {% include video-no-background.html
+          src="https://d7rcwrflqckpu.cloudfront.net/Academic_sl/Kokaji-Kiri_Chunori.mp4"
+          link="Chūnori"
+          title="Kokaji/Kiri"
+        %}
+
+        <h4 id="TextSetting">Text setting exceptions</h4>
+
+        <p> Occasionally, lines of text do not fit within the 7 + 5 model. The number of syllables for the first hemistich can vary between two and ten, and three and eight for the second one. There are two methods that allow for the rhythmic adjustment of syllables: the first one involves starting the line's first syllable on a different beat, whereas the second method involves the insertion of measures of various sizes.</p>
+
+        <p>The standard position for the first syllable of a line of text is on the upbeat leading to the <em>honji's</em> first downbeat. Thus, one method of fitting a larger than twelve syllables line of text within a <em>honji</em> consist of starting its first syllable earlier than the standard upbeat to the first beat. For example, the last line of text of Hashitomi’s first <em>Ageuta</em> is comprised of thirteen syllables: 8 + 5.</p>
+
+        {% include image-no-background.html
+          src="/assets/images/FirstMethod-Text.png"
+          %}
+
+        <p>In this case, ‘Ta,’ the first syllable, starts on the eighth downbeat as seen below instead of the usual upbeat to the very first beat:</p>
+
+        {% include image-no-background.html
+          src="/assets/images/FirstMethod-Rhythm.png"
+        %}
+
+        <p>The second method of setting lines of text that exceed twelve syllables consists of introducing measures of two (<em>okuriji</em>), four (<em>toriji</em>), or six (<em>kataji</em>) beats. For example, here are the first three lines of Kokaji’s <em>Kiri</em>. Its syllabic structure is: 7 + 5, 7 + 6, and 9 + 5.</p>
+
+        {% include image-no-background.html
+          src="/assets/images/2ndMethod-Text.png"
+        %}
+        <p> A <em>toriji</em> (measure of four beats) has been inserted between the second and third <em>honji</em> (eight beat unit) in order to counter-balance the odd syllabic structure of the text. When it comes to measures other than the <em>honji</em>, the <em>toriji</em> is far more common that the two- and six-beat measures.</p>
+        {% include image-no-background.html
+          src="/assets/images/2ndMethod-Rhythm.png"
+        %}
+
+        <h3 id="Non-congruent">Non-congruent (<em>hyōshi-awazu</em>)</h3>
+
+        <p>The emphasis for non-congruent chants is on the text and melodic line. With this text setting there is no coordination between syllables and the unit’s eight beats. There are two types of non-congruent chant: <em>sashinori</em> and <em>einori</em>.</p>
+
+        <p><em>Sashinori</em> chant is always accompanied by the ōtsuzumi and kotsuzumi in a flexible setting, while <em>einori</em> chant can be accompanied by the hand percussion instruments in either strict or flexible setting. If the chant includes a nohkan part it will also be non-congruent.</p>
+
+
+        <h4 id="Sashinori">Sashinori</h4>
+
+        <p><em>Sashinori</em> chants are sung in a recitative style, accompanied by the ōtsuzumi and kotsuzumi in flexible setting, favoring the sparse <em>mitsuji</em> patterns. On the other hand, the <em>Kuri</em> also accompanied by the two hand-drums in flexible setting, favors the <em>tsuzuke</em> pattern.  There is a Japanese expression that describes well the idea behind a non-congruent chant accompanied by percussions in flexible rhythmic setting: <em>fusoku furi</em> which means ‘not separate but not together’.</p>
+
+        <p>The <em>Sashi</em> from Kokaji, sung in <em>tsuyogin</em> mode, is composed of two parts. Each one begins by a solo performed the shite followed by a reply by the jiutai. The reply is broken up into melodic lines rhythmically characterized by a slightly accelerated pulse that becomes a sustained tone. The sustained tones are positioned on syllables that reinforce the text's structure or meaning. For the most part, each line stays on the high tone, usually preceded with an inflection from below. Finally, the chant concludes on the low tone.</p>
+
+        <p>The score provided for this excerpt shows the first part is composed of six lines, each concluded by a sustained tone: the shite presents the first, the jiutai the next five, identified in the score with the numbers 1 to 6. It is the two percussionists' responsibility to position their four <em>mitsuji</em> patterns against these six lines.</p>
+
+        {% include video-no-background.html
+          src="https://d7rcwrflqckpu.cloudfront.net/Academic_sl/Kokaji-Sahi_Sashinori.mp4"
+          link="Sashinori"
+          title="Kokaji/Sashi"
+        %}
+
+        <h4 id="Einori">Einori</h4>
+
+        <p> <em>Einori</em> chants are usually accompanied by the ōtsuzumi and kotsuzumi in strict setting. The <em>Issei-</em>chant from Hashitomi is sung in <em>yowagin</em> style, focusing on only four tones: the Medium and High, and their respective Intermediate tones a second lower. It is divided up into two segments: the first one sung by the shite, the second one by the jiutai.</p>
+
         <p>The hand-percussion instruments start both parts with sparse <em>mitsuji</em> patterns before moving on with <em>tsuzuke</em> patterns. It is while performing the <em>mitsuji</em> patterns that the ōtsuzumi player has some flexibility to adapt to the melodic line. This is particularly clear with this recording. The ōtsuzumi player uses flexible <em>kakegoe</em> when performing the first <em>mitsuji</em> patterns, whereas the kotsuzumi player uses the strict <em>kakegoe</em> throughout the chant.
-        </p>
-
-        {% include video-no-background.html
-          src="https://d7rcwrflqckpu.cloudfront.net/Shodan_sl/Hashitomi-Issei_chant_Score_sl.mp4"
-          link="Einori"
-          title="Hashitomi/Issei"
-        %}
-      </div>
-    </section>
-  </div>
-
-</main>
+        </p>
+
+        {% include video-no-background.html
+          src="https://d7rcwrflqckpu.cloudfront.net/Shodan_sl/Hashitomi-Issei_chant_Score_sl.mp4"
+          link="Einori"
+          title="Hashitomi/Issei"
+        %}
+      </div>
+    </section>
+  </div>
+
+</main>

--- a/src/_music/voices.html
+++ b/src/_music/voices.html
@@ -43,49 +43,28 @@ fourth-level-menu-active: voices
             <div class="wrapper">
               <section title="Waki" id="KotobaWaki">
                 {% include video-no-background.html
-
-                  src="https://d7rcwrflqckpu.cloudfront.net/Shodan_sl/Hashitomi-Nanori_Score_sl.mp4"
-
-                  link=""
-
-                  title="Hashitomi – Nanori "
-
-                  paragraph1="The calm delivery in the lower register is well suited for a traveling monk."
-
+                   src="https://d7rcwrflqckpu.cloudfront.net/Shodan_sl/Hashitomi-Nanori_Score_sl.mp4"
+                   title="Hashitomi – Nanori "
+                   paragraph1="The calm delivery in the lower register is well suited for a traveling monk."
                 %}
 
               </section>
               <section title="Wakizure" id="KotobaWakizure">
 
                 {% include video-no-background.html
-
-                  src="https://d7rcwrflqckpu.cloudfront.net/Shodan_sl/Kokaji-Nanori_Score_sl.mp4"
-
-                  link=""
-
-                  title="Kokaji – Nanori "
-
-                  paragraph1="The fast speed and use of the higher register is well suited for delivering an urgent order."
-
+                   src="https://d7rcwrflqckpu.cloudfront.net/Shodan_sl/Kokaji-Nanori_Score_sl.mp4"
+                   title="Kokaji – Nanori "
+                   paragraph1="The fast speed and use of the higher register is well suited for delivering an urgent order."
                 %}
 
 
               </section>
               <section title="Shite and Waki" id="KotobaShiteWaki">
                 {% include video-no-background.html
-
-                  src="https://d7rcwrflqckpu.cloudfront.net/Shodan_sl/Kokaji-Mondō_Score_sl.mp4"
-
-                  link=""
-
-                  title="Kokaji – Mondō"
-
-                  paragraph1="The <em>Mondō</em> from Kokaji is a spoken dialogue between the shite (a divine being) and waki (sword maker). The former sits on the left, and the latter on the right. This example offers two points of comparison between the <em>kotoba</em> styles of shite and waki."
-
-
-
-                  paragraph2="The first point relates to the gradual rising tone. While they both use a rising line to get to a peak-tone, the overall ascent of the shite’s line is more subdued compared with the waki’s. The second point relates to the rhythm of delivery, since the shite’s is much slower than the waki."
-
+                   src="https://d7rcwrflqckpu.cloudfront.net/Shodan_sl/Kokaji-Mondō_Score_sl.mp4"
+                   title="Kokaji – Mondō"
+                   paragraph1="The <em>Mondō</em> from Kokaji is a spoken dialogue between the shite (a divine being) and waki (sword maker). The former sits on the left, and the latter on the right. This example offers two points of comparison between the <em>kotoba</em> styles of shite and waki."
+                   paragraph2="The first point relates to the gradual rising tone. While they both use a rising line to get to a peak-tone, the overall ascent of the shite’s line is more subdued compared with the waki’s. The second point relates to the rhythm of delivery, since the shite’s is much slower than the waki."
                 %}
 
               </section>
@@ -112,13 +91,13 @@ fourth-level-menu-active: voices
             {% include image-no-background.html src="/assets/images/Yowagin-range.jpg" %}
 
             {% include video-no-background.html
-            src="https://d7rcwrflqckpu.cloudfront.net/Academic_sl/Hagoromo-Kuri_yowagin_Range_sl.mp4"
-            link="Yowagin"
-            title="Hagoromo/Kuri"
-            paragraph1="The module is named after the <em>kuri </em> tone from the higher register. For the most part, the melodic material of the piece focuses on the High tone with few incursions on the <em>kuri</em>, shown in bold in the text of the video."
-
-            paragraph2="Upon reaching the <em>kuri</em>’s signature cadential melisma, the <em>hon-yuri</em>, the melodic material switches to Medium before cadencing on the Low. (The pitch material in this performance is a major second lower than the one shown in the figure above)."
-            paragraph3="The registers in the video are symbolized by the following letters: L (Low), M (Medium), H (High), K (Kuri)."%}
+               src="https://d7rcwrflqckpu.cloudfront.net/Academic_sl/Hagoromo-Kuri_yowagin_Range_sl.mp4"
+               link="Yowagin"
+               title="Hagoromo/Kuri"
+               paragraph1="The module is named after the <em>kuri </em> tone from the higher register. For the most part, the melodic material of the piece focuses on the High tone with few incursions on the <em>kuri</em>, shown in bold in the text of the video."
+               paragraph2="Upon reaching the <em>kuri</em>’s signature cadential melisma, the <em>hon-yuri</em>, the melodic material switches to Medium before cadencing on the Low. (The pitch material in this performance is a major second lower than the one shown in the figure above)."
+               paragraph3="The registers in the video are symbolized by the following letters: L (Low), M (Medium), H (High), K (Kuri)."
+            %}
 
 
 
@@ -131,11 +110,11 @@ fourth-level-menu-active: voices
 
             {% include image-no-background.html src="/assets/images/Tsuyoggin-range.png" %}
       {% include video-no-background.html
-        src="https://d7rcwrflqckpu.cloudfront.net/Academic_sl/Kokaji-Kuri_tsuyogin_Range_sl.mp4"
-        link="Tsuyogin"
-        title="Kokaji/Kuri"
-        paragraph1="The section's name refers to the high tone <em>kuri</em>, so this section's melody is set in the higher register."
-        paragraph2="The registers in the video are symbolized by the following letters: L (Low), H (High), K (Kuri)."
+         src="https://d7rcwrflqckpu.cloudfront.net/Academic_sl/Kokaji-Kuri_tsuyogin_Range_sl.mp4"
+         link="Tsuyogin"
+         title="Kokaji/Kuri"
+         paragraph1="The section's name refers to the high tone <em>kuri</em>, so this section's melody is set in the higher register."
+         paragraph2="The registers in the video are symbolized by the following letters: L (Low), H (High), K (Kuri)."
       %}
 
 
@@ -190,13 +169,9 @@ fourth-level-menu-active: voices
 
 
                   {% include video-no-background.html
-
-                    src="https://d7rcwrflqckpu.cloudfront.net/Academic_sl/Hashitomi-Ageuta1_tsuzukeutai.mp4"
-
-                    link="Tsuzuke utai"
-
-                    title="Hashitomi/Ageuta-1"
-
+                     src="https://d7rcwrflqckpu.cloudfront.net/Academic_sl/Hashitomi-Ageuta1_tsuzukeutai.mp4"
+                     link="Tsuzuke utai"
+                     title="Hashitomi/Ageuta-1"
                   %}
 
 
@@ -218,13 +193,9 @@ fourth-level-menu-active: voices
 
 
                       {% include video-no-background.html
-
-                        src="https://d7rcwrflqckpu.cloudfront.net/Academic_sl/Hashitomi-Ageuta1_mitsujiuta.mp4"
-
-                        link="Mitsuji-utai"
-
-                        title="Hashitomi/Ageuta 1"
-
+                         src="https://d7rcwrflqckpu.cloudfront.net/Academic_sl/Hashitomi-Ageuta1_mitsujiuta.mp4"
+                         link="Mitsuji-utai"
+                         title="Hashitomi/Ageuta 1"
                       %}
 
               </section>
@@ -254,13 +225,9 @@ fourth-level-menu-active: voices
 
 
                 {% include video-no-background.html
-
-                  src="https://d7rcwrflqckpu.cloudfront.net/Academic_sl/Hashitomi-Ageuta1_Utai_sl.mp4"
-
-                  link="Hiranori styles in context"
-
-                  title="Hashitomi/Ageuta 1"
-
+                   src="https://d7rcwrflqckpu.cloudfront.net/Academic_sl/Hashitomi-Ageuta1_Utai_sl.mp4"
+                   link="Hiranori styles in context"
+                   title="Hashitomi/Ageuta 1"
                 %}
 
               </section>
@@ -280,9 +247,9 @@ fourth-level-menu-active: voices
         %}
 
         {% include video-no-background.html
-          src="https://d7rcwrflqckpu.cloudfront.net/Academic_sl/Kokaji-Noriji2_Onori.mp4"
-          link="Ōnori"
-          title="Kokaji/Noriji 2"
+           src="https://d7rcwrflqckpu.cloudfront.net/Academic_sl/Kokaji-Noriji2_Onori.mp4"
+           link="Ōnori"
+           title="Kokaji/Noriji 2"
         %}
 
         <h4 id="Chunori">Chūnori</h4>
@@ -294,9 +261,9 @@ fourth-level-menu-active: voices
           src="/assets/images/Chunori.png"
         %}
         {% include video-no-background.html
-          src="https://d7rcwrflqckpu.cloudfront.net/Academic_sl/Kokaji-Kiri_Chunori.mp4"
-          link="Chūnori"
-          title="Kokaji/Kiri"
+           src="https://d7rcwrflqckpu.cloudfront.net/Academic_sl/Kokaji-Kiri_Chunori.mp4"
+           link="Chūnori"
+           title="Kokaji/Kiri"
         %}
 
         <h4 id="TextSetting">Text setting exceptions</h4>
@@ -341,9 +308,9 @@ fourth-level-menu-active: voices
         <p>The score provided for this excerpt shows the first part is composed of six lines, each concluded by a sustained tone: the shite presents the first, the jiutai the next five, identified in the score with the numbers 1 to 6. It is the two percussionists' responsibility to position their four <em>mitsuji</em> patterns against these six lines.</p>
 
         {% include video-no-background.html
-          src="https://d7rcwrflqckpu.cloudfront.net/Academic_sl/Kokaji-Sahi_Sashinori.mp4"
-          link="Sashinori"
-          title="Kokaji/Sashi"
+           src="https://d7rcwrflqckpu.cloudfront.net/Academic_sl/Kokaji-Sahi_Sashinori.mp4"
+           link="Sashinori"
+           title="Kokaji/Sashi"
         %}
 
         <h4 id="Einori">Einori</h4>
@@ -354,9 +321,9 @@ fourth-level-menu-active: voices
         </p>
 
         {% include video-no-background.html
-          src="https://d7rcwrflqckpu.cloudfront.net/Shodan_sl/Hashitomi-Issei_chant_Score_sl.mp4"
-          link="Einori"
-          title="Hashitomi/Issei"
+           src="https://d7rcwrflqckpu.cloudfront.net/Shodan_sl/Hashitomi-Issei_chant_Score_sl.mp4"
+           link="Einori"
+           title="Hashitomi/Issei"
         %}
       </div>
     </section>

--- a/src/_sass/components/website/video-tooltip.scss
+++ b/src/_sass/components/website/video-tooltip.scss
@@ -23,7 +23,7 @@
 
   &:hover {
     & + .video-website__tooltip {
-      display: block;
+      opacity: 1;
     }
   }
 }
@@ -37,7 +37,7 @@
 
 .video-website__tooltip {
   background-color: $black80;
-  display: none;
+  opacity: 0;
   height: 100%;
   left: 0;
   padding: 1.5rem 1rem;
@@ -45,6 +45,11 @@
   top: 0;
   width: 100%;
   z-index: 10;
+  pointer-events: none;
+  transition: opacity .2s ease;
+  &:hover {
+    opacity: 1;
+  }
 }
 
 .video-website__description {

--- a/src/_sass/components/website/video-tooltip.scss
+++ b/src/_sass/components/website/video-tooltip.scss
@@ -4,6 +4,7 @@
 .video-website__toggle {
   background-color: $black48;
   color: $white;
+  cursor: help;
   display: inline-block;
   margin: 0 auto 0.5rem auto;
   max-width: $wrapper-media;
@@ -11,11 +12,13 @@
   position: absolute;
   right: 0;
   text-align: right;
+  text-decoration: none;
   top: 0;
   z-index: 11;
 
-  .fas {
-    margin-left: 0.5rem;
+  strong {
+    margin-right: 0.5rem;
+    text-decoration: underline;
   }
 
   &:hover {


### PR DESCRIPTION
* Prevent navigation on click
* Change the tooltip cursor
* Apply minimal fade-in effect
* Apply padding and underlining appropriately for link titles (i.e. according to their presence or absence)
* Render links titles and paragraphs only if there's content (previously lots of empty tags were rendered)

Closes #524.