### PR TITLE
Updates to ITI table

### DIFF
--- a/src/_sass/components/website/content-table.scss
+++ b/src/_sass/components/website/content-table.scss
@@ -45,6 +45,38 @@
 
 }
 
+#content-table--iti__show-all {
+  display: none;
+
+  ~ label {
+    float:right;
+    text-transform: uppercase;
+
+    &::before {
+      content: "show all";
+    }
+  }
+
+  &:checked {
+    ~ label::before {
+      content: "collapse";
+    }
+
+    ~ .content-table--iti {
+
+      &::after {
+        display: none;
+      }
+
+      tbody {
+        max-height: none;
+      }
+    }
+  }
+
+}
+
+
 .content-table__row {
   border-bottom: $border;
 

--- a/src/_sass/components/website/content-table.scss
+++ b/src/_sass/components/website/content-table.scss
@@ -10,6 +10,14 @@
   @extend .content-table;
 }
 
+.content-table--iti {
+  @extend .content-table;
+
+  .content-table__column {
+    min-width: auto;
+  }
+}
+
 .content-table__row {
   border-bottom: $border;
 

--- a/src/_sass/components/website/content-table.scss
+++ b/src/_sass/components/website/content-table.scss
@@ -13,9 +13,36 @@
 .content-table--iti {
   @extend .content-table;
 
+  thead {
+    display: block;
+    overflow-y: scroll;
+    width: 100%;
+  }
+
+  tr {
+    display: table;
+    width: 100%;
+  }
+
+  tbody {
+    max-height: 400px;
+    display: block;
+    overflow-y: auto;
+  }
+
   .content-table__column {
     min-width: auto;
+    padding: .5rem;
   }
+
+  td:nth-of-type(1) { width: 6%; }
+  td:nth-of-type(2) { width: 19%; }
+  td:nth-of-type(3) { width: 9%; }
+  td:nth-of-type(4) { width: 19%; }
+  td:nth-of-type(5) { width: 9%; }
+  td:nth-of-type(6) { width: 19%; }
+  td:nth-of-type(7) { width: 19%; }
+
 }
 
 .content-table__row {
@@ -66,8 +93,9 @@
     color: $green;
     font-weight: $fw-semibold;
     vertical-align: middle;
-  
+
     @include text(xxs);
     @include uppercase();
+    text-align: left;
   }
 }

--- a/src/form.html
+++ b/src/form.html
@@ -1,651 +1,651 @@
----
-layout: website
-title: Form
-menu-active: elements
-second-level-menu-active: form
-permalink: /form/
----
-
-{% include second-menu-elements.html %}
-
-<main class="page-content">
-  <div class="text-container">
-
-    <div class="wrapper sidebar-contents">
-      <aside class="sidebar-contents__table">
-        {% include menu-form.html %}
-      </aside>
-      <section class="sidebar-contents__section">
-        <div class="text-container">
-          <h2 id="Intro">Form</h2>
-<h3>Introduction</h3>
-
-
-<p>Zeami (c.1363- c.1443) is credited with having perfected Noh as it exists today. When it came to form, he adapted the Gagaku concept of modulation and movement called <em>Jo-ha-kyū</em>. The tripartite can be summarized as: <em>Jo</em> - slow, <em>Ha</em> - development / acceleration, and <em>Kyū</em> - fast conclusion, suggesting that most efforts should start slowly, speed up, before rapidly ending. Zeami expanded the model from three to five sections by nesting the <em>Jo-ha-kyū</em> concept within the <em>Ha</em>, the tripartite’s longest section. Thus, his adaptation can be summarized as: <em>Jo, Ha-jo, Ha-ha, Ha-kyū, Kyū</em>.</p>
-
-<p>Eventually, the principle of <em>Jo-ha-kyū</em> was applied to various levels of organization. For instance, its basic idea of acceleration has shaped <a href="/catalog-of-shodan/nanori" target="_blank">declamation</a> and <a href="/movement/forward/" target="_blank">movements</a>, among others.</p>
-
-<h3 id="Dan">Dan</h3>
-
-<p>It is the modern scholar, Mario Yokomichi (1916-2012) who created a framework to understand the form of Noh play. Referencing Zeami’s five-section concept, he analyzed the form of typical two acts’ Noh plays attributed to Zeami. Then, he has formulated that each act consists of five sections called <em>dan</em>, that represent common events in the dramatic development of a Noh play.  These are:</p>
-
-<table class="content-table">
-<tr class="content-table__row--header">
-
-<td id="Act1" class="content-table__column">Act I (<em>mae ba</em>)</td>
-
-<td class="content-table__column"></td>
-<td class="content-table__column"></td>
-<td class="content-table__column"></td>
-<td class="content-table__column"></td>
-</tr>
-  <tr class="content-table__row">
-          <td class="content-table__column">Waki Enters</td>
-          <td class="content-table__column">Shite Enters</td>
-          <td class="content-table__column">Dialogue</td>
-          <td class="content-table__column">Shite Performs</td>
-          <td class="content-table__column">Shite Exits</td></tr>
-          <tr class="content-table__row--header">
-
-<td id="Act2" class="content-table__column">Act II (<em>nochi ba</em>)</td>
-
-<td class="content-table__column"></td>
-<td class="content-table__column"></td>
-<td class="content-table__column"></td>
-<td class="content-table__column"></td>
-</tr>
-  <tr class="content-table__row">
-          <td class="content-table__column">Waki Waits</td>
-          <td class="content-table__column">Shite Re-enters</td>
-          <td class="content-table__column">Dialogue</td>
-          <td class="content-table__column">Shite Performs</td>
-          <td class="content-table__column">Shite Exits</td></tr>
-</table>
-
-<p>The above categorizations agree with the traditional divisions shared by actors and musicians. However, we need to acknowledge that the Zeami/Yokomichi’s model is an ideal meant only to help the understanding of an act and facilitate comparisons between plays.  It is not uncommon that some Noh plays lack certain <em>dan</em>. </p>
-
-<h3 id="shodan">Shōdan</h3>
-<p> According to Yokomichi, a <em>dan</em> consists of one or more <em>shōdan</em>. These are conventional units of form that have their own position and syntactical role within a <em>dan</em>. The word <em>shōdan</em>, meaning ‘small dan’, was coined by Mario Yokomichi to further explain the hierarchical character of the form of a Noh play. There are about one hundred different kinds of <em>shōdan</em> that can be categorized into four types: Spoken, Chanted, Entrance and Exit music, and Dance music. Each <em>shōdan</em> is also characterized by a particular combination of poetry or prose, rhythmic setting, melodic shape, and instrumentation. </p>
+---
+layout: website
+title: Form
+menu-active: elements
+second-level-menu-active: form
+permalink: /form/
+---
 
-<p>The same shōdan can be found in various plays. For instance, the majority of Noh plays include a <a href="/catalog-of-shodan/nanori/" target="_blank"><em>nanori</em></a>, a spoken introduction presented by the secondary actor. It can be found <a href="/hashitomi/nanori/" target="_blank">in Hashitomi</a> as well as <a href="/kokaji/nanori/" target="_blank">in Kokaji</a>. Moreover, the same shōdan, such as the main chant <a href="/catalog-of-shodan/ageuta/" target="_blank"><em>ageuta</em></a> for instance, can be used more than once in a play. For example, Hashitomi has two while Kokaji has three. For more information and video examples of <em>shōdan</em> please refer to the <a href="/catalog-of-shodan/" target="_blank">Catalog of Shōdan</a>.</p>
-
-<p> This  <a href="/form-appendix/" target="_blank">appendix</a> provides information on the <em>shōdan</em> commonly associated with the various <em>dan</em>. It is presented solely as a reference-model, since a comparison limited to Hashitomi and Kokaji's form would already show that deviations from that model are not at all uncommon.</p>
-
-<h3 id="modularity">Modularity</h3>
-<p>Thus, the construction of Noh plays, made of sequences of <em>dan</em>, themselves composed of <em>shōdan</em>, is said to be modular. In Noh, the concept of modularity is not exclusively found at the overall formal level, but also within individual media layers such as dance and music. For instance, the nohkan’s melodic patterns are themselves sequenced from shorter modules. The nohkan player varies the patterns' expression to adapt them to given contexts, as illustrated with these examples: <a href="/music/nohkan/nakanotakane/" target="_blank"><em>naka no takane</em></a> and <a href="/music/nohkan/takanemikusari/" target="_blank"><em>takane mi kusari</em></a>. </p>
-
-<p>The patterns played by the percussionists are similarly constructed and controlled. This <a href="/music/otsuzumi-kotsuzumi/#patterns" target="_blank">example</a> shows how the rhythms played by the ōtsuzumi and kotsuzumi performers for an <a href="/catalog-of-shodan/ashirai" target="_blank"><em>Ashirai</em></a>, involve the juxtaposition of <em>mitsuji</em> and <em>tsuzuke</em> patterns. It also illustrates how their expression is altered when the rhythmic setting is strict compared to flexible.</p>
-
-<p>Similarly, dances are constructed using a limited number of movements (<em>kata</em>) that are reused within a dance, a play, and even across plays. Moreover, modularity can be seen in the way that some <em>kata</em> are designed. For instance, the <a href="/movement/back-circlet/" target="_blank">Back Circlet</a> is composed of the sequence of two shorter <em>kata</em>: a Right Step pivot followed by an Open-retreat.  Similarly to music, the unifying impact of modularity is balanced by changing expressive interpretation of patterns performed in a different context. This is shown in a comparison of <a href="/movement/large-zigzag/" target="_blank">two versions</a> of the Large Zigzag: first, as it is performed by a pensive ghost of a young woman in Hashitomi and second, in martial style as performed by the vigorous diety in Kokaji. For more examples of <em>kata</em> please refer to the <a href="/movement/" target="_blank">Catalog of <em>Kata</em></a>.</p>
-
-<h3 id="Both">The Form of Hashitomi and Kokaji</h3>
-
-<p>The Zeami/Yokomichi model should be viewed as a reference rather than an absolute, since few plays follow it exactly. Hashitomi and Kokaji’s form  underlines this point, since both deviate from it somewhat.</p>
-
-<p>In the following two figures, the section's name is linked to the beginning of that section within the play, while the <em>shōdan</em> are linked to their respective intermedia analysis. Not shown in the model but present in both plays is the <em>kyōgen</em> interlude. It is often performed between the two acts but there are no <em>shōdan</em> associated with it. Usually, a <a href="/actors/#Ai" target="_blank">kyōgen</a> actor enters at that moment and engages with the waki. Acting as a local who is well informed about the place’s history, he introduces information that connects the first and second acts.</p>
-
-<h4 id="Hashitomi">Hashitomi</h4>
-
-<p>This figure summarizes Hashitomi's form. It differs from Zeami/Yokomichi model primarily with the missing ‘Shite Performs’ section in the first act, a difference that is not unique to Hashitomi.</p>
-
-            <table class="content-table">
-
-              <tr class="content-table__row--header">
-                <td id="hashitomi-first-act" class="content-table__column">First act <br>(<em>mae ba</em>)</td>
-                <td class="content-table__column"></td>
-                <td class="content-table__column"></td>
-                <td class="content-table__column"></td>
-                <td class="content-table__column"></td>
-              </tr>
-
-              <tr class="content-table__row">
-                <td class="content-table__column"><a href="/hashitomi/#startTime=00:03:38" target="_blank">Waki
-                    Enters</a></td>
-                <td class="content-table__column"><a href="/hashitomi/#startTime=00:08:56" target="_blank">Shite
-                    Enters</a></td>
-                <td class="content-table__column"><a href="/hashitomi/#startTime=00:14:02" target="_blank">Dialogue</a>
-                </td>
-                <td class="content-table__column">
-                  <p>Shite Performs</p>
-                </td>
-                <td class="content-table__column"><a href="/hashitomi/#startTime=00:17:29" target="_blank">Shite
-                    Exits</a></td>
-              </tr>
-
-              <tr class="content-table__row"></tr>
-
-              <tr class="content-table__row">
-                <td class="content-table__column">
-                  <a href="/hashitomi/nanoribue/" target="_blank"><em>Nanoribue</em></a><br>
-                  <a href="/hashitomi/nanori/" target="_blank"><em>Nanori</em></a><br>
-                  <a href="/hashitomi/kakaru-1/" target="_blank"><em>Kakaru 1</em></a>
-                </td>
-
-                <td class="content-table__column">
-                  <a href="/hashitomi/ashirai/" target="_blank"><em>Ashirai</em></a><br>
-                  <a href="/hashitomi/song/" target="_blank"><em>Song</em></a>
-                </td>
-
-                <td class="content-table__column">
-                  <a href="/hashitomi/kakeai/" target="_blank"><em>Kakeai</em></a>
-                </td>
-
-                <td class="content-table__column"> – </td>
-
-                <td class="content-table__column">
-                  <a href="/hashitomi/kakaru-2/" target="_blank"><em>Kakaru 2</em></a><br>
-                  <a href="/hashitomi/ageuta-1/" target="_blank"><em>Ageuta 1</em></a></td>
-
-              </tr>
-            </table>
-
-            <table class="content-table">
-
-              <tr class="content-table__row--header">
-                <td id="hashitomi-second-act" class="content-table__column">Second act <br>(<em>nochi ba</em>)</td>
-                <td class="content-table__column"></td>
-                <td class="content-table__column"></td>
-                <td class="content-table__column"></td>
-                <td class="content-table__column"></td>
-              </tr>
-
-              <tr class="content-table__row">
-                <td class="content-table__column"><a href="/hashitomi/#startTime=00:39:23" target="_blank">Waki
-                    Waits</a></td>
-                <td class="content-table__column"><a href="/hashitomi/#startTime=00:40:56" target="_blank">Shite
-                    Re-enters</a></td>
-                <td class="content-table__column"><a href="/hashitomi/#startTime=00:47:15" target="_blank">Dialogue</a>
-                </td>
-                <td class="content-table__column"><a href="/hashitomi/#startTime=00:51:58" target="_blank">Shite
-                    Performs</td>
-                <td class="content-table__column"><a href="/hashitomi/#startTime=01:17:26" target="_blank">Shite
-                    Exits</a></td>
-              </tr>
-
-              <tr class="content-table__row"></tr>
-
-              <tr class="content-table__row">
-                <td class="content-table__column">
-                  <a href="/hashitomi/kakaru-3/" target="_blank"><em>Kakaru 3</em></a>
-                </td>
-
-                <td class="content-table__column">
-                  <a href="/hashitomi/issei/" target="_blank"><em>Issei</em></a><br>
-                  <a href="/hashitomi/sageuta/" target="_blank"><em>Sageuta</em></a><br>
-                  <a href="/hashitomi/ageuta-2/" target="_blank"><em>Ageuta 2</em></a>
-                </td>
-
-                <td class="content-table__column">
-                  <a href="/hashitomi/rongi/" target="_blank"><em>Rongi</em></a></td>
-
-                <td class="content-table__column">
-                  <a href="/hashitomi/kuse/" target="_blank"><em>Kuse</em></a><br>
-                  <a href="/hashitomi/jonomai/" target="_blank"><em>Jonomai</em></a>
-                </td>
-                <td class="content-table__column">
-                  <a href="/hashitomi/waka/" target="_blank"><em>Waka</em></a><br>
-                  <a href="/hashitomi/kiri/" target="_blank"><em>Kiri</em></a>
-                </td>
-
-              </tr>
-            </table>
-<h4 id="Kokaji">Kokaji</h4>
-
-<p>The figure below summarizes Kokaji's form. It differs from Zeami/Yokomichi with the missing 'Shite Enters' <em>dan</em> in the first act and the ‘Dialogue’ <em>dan</em> in the second. Neither absence is unusual. The actual appearance of the first-act shite happens at the beginning of the 'Dialogue' <em>dan</em>. </p>
-
-            <table class="content-table">
-
-              <tr class="content-table__row--header">
-                <td id="kokaji-first-act" class="content-table__column">First act <br>(<em>mae ba</em>)</td>
-                <td class="content-table__column"></td>
-                <td class="content-table__column"></td>
-                <td class="content-table__column"></td>
-                <td class="content-table__column"></td>
-              </tr>
-
-              <tr class="content-table__row">
-                <td class="content-table__column"><a href="/kokaji/#startTime=00:03:55" target="_blank">Waki Enters</a>
-                </td>
-                <td class="content-table__column">
-                <p>Shite Enters</p>
-                </td>
-
-                <td class="content-table__column"><a href="/kokaji/#startTime=00:12:18" target="_blank">Dialogue</a>
-                </td>
-                <td class="content-table__column"><a href="/kokaji/#startTime=00:16:55" target="_blank">Shite
-                    Performs</a></td>
-                <td class="content-table__column"><a href="/kokaji/#startTime=00:29:07" target="_blank"> Shite Exits</a>
-                </td>
-              </tr>
-
-              <tr class="content-table__row"></tr>
-
-              <tr class="content-table__row">
-                <td class="content-table__column">
-                  <a href="/kokaji/nanori/" target="_blank"><em>Nanori</em></a><br>
-                  <a href="/kokaji/mondo-1/" target="_blank"><em>Mondō 1</em></a><br>
-                  <a href="/kokaji/ageuta-1/" target="_blank"><em>Ageuta 1</em></a><br>
-                  <a href="/kokaji/dialogue/" target="_blank"><em>Dialogue</em></a><br>
-                  <a href="/kokaji/monologue/" target="_blank"><em>Monologue</em></a>
-                </td>
-
-                  <td class="content-table__column"> – </td>
-
-                <td class="content-table__column">
-                  <a href="/kokaji/mondo-2/" target="_blank"><em>Mondō 2</em></a><br>
-                  <a href="/kokaji/ageuta-2/" target="_blank"><em>Ageuta 2</em></a>
-                </td>
-
-
-                <td class="content-table__column">
-                  <a href="/kokaji/kuri/" target="_blank"><em>Kuri</em></a><br>
-                  <a href="/kokaji/sashi/" target="_blank"><em>Sashi</em></a><br>
-                  <a href="/kokaji/kuse/" target="_blank"><em>Kuse</em></a>
-                </td>
-
-                <td class="content-table__column">
-                  <a href="/kokaji/kakeai-1/" target="_blank"><em>Kakeai 1</em></a><br>
-                  <a href="/kokaji/ageuta-3/" target="_blank"><em>Ageuta 3</em></a><br>
-                  <a href="/kokaji/raijo/" target="_blank"><em>Raijo</em></a>
-                </td>
-
-              </tr>
-            </table>
-
-            <table class="content-table">
-
-              <tr class="content-table__row--header">
-                <td id="kokaji-second-act" class="content-table__column">Second act <br>(<em>nochi ba</em>)</td>
-                <td class="content-table__column"></td>
-                <td class="content-table__column"></td>
-                <td class="content-table__column"></td>
-                <td class="content-table__column"></td>
-              </tr>
-
-              <tr class="content-table__row">
-                <td class="content-table__column"><a href="/kokaji/#startTime=00:45:14" target="_blank"> Waki Waits</a>
-                </td>
-                <td class="content-table__column"><a href="/kokaji/#startTime=00:51:07" target="_blank"> Shite
-                    Re-enters</a></td>
-                <td class="content-table__column">
-                  <p>Dialogue</p>
-                </td>
-                <td class="content-table__column"><a href="/kokaji/#startTime=00:52:30" target="_blank"> Shite
-                    Performs</a></td>
-                <td class="content-table__column"><a href="/kokaji/#startTime=00:56:10" target="_blank"> Shite Exits</a>
-                </td>
-              </tr>
-
-              <tr class="content-table__row"></tr>
-
-              <tr class="content-table__row">
-                <td class="content-table__column">
-                  <a href="/kokaji/notto/" target="_blank"><em>Notto</em></a><br>
-                  <a href="/kokaji/noriji-1/" target="_blank"><em>Noriji 1</em></a>
-
-                </td>
-
-                <td class="content-table__column">
-                  <a href="/kokaji/hayafue/" target="_blank"><em>Hayafue</em></a>
-                </td>
-
-                <td class="content-table__column"> – </td>
-
-                <td class="content-table__column">
-                  <a href="/kokaji/noriji-2/" target="_blank"><em>Noriji 2</em></a><br>
-                  <a href="/kokaji/maibataraki/" target="_blank"><em>Maibataraki</em></a><br>
-                  <a href="/kokaji/noriji-3/" target="_blank"><em>Noriji 3</em></a>
-                </td>
-                <td class="content-table__column">
-                  <a href="/kokaji/kakeai-2/" target="_blank"><em>Kakeai 2</em></a><br>
-                  <a href="/kokaji/kiri/" target="_blank"><em>Kiri</em></a>
-                </td>
-
-              </tr>
-            </table>
-
-<h3 id="ITI">Intermedia Texture Index</h3>
-            <p>The focus of our website asked for a general structural representation of Noh that takes into account its intermedia nature. Interestingly, certain qualities in media layers of Noh change predictibly as the play progresses. These layer-based structural tendencies can be observed in particular qualities of text, dance, singing and rhythmic setting of the music, as well as the type of coordination between all of them. We decided to find a system to represent the intermedia tendencies and flow in a graph. We refer to its values as Intermedia Texture Index (ITI). According to our rules, layers exhibiting qualities of a typical earlier stage in the play received fewer and later stage, more 'points'. The 'points' of all graded media layers in a <em>shōdan</em> are then added to give a <em>shōdan</em> its rank. We used this system to assign a rank to all <em>shōdan</em> in the two plays. The resulting sequence of ITI values show how the form of each play is articulated cummulatively by its three main media layers. Obviously, turning rich theatrical experience into numbers is highly reductive but we found the abstraction informative in comparing the flow of intermedia development in different plays.</p>
-            <p>
-            The following explains the rationale of our ranking system for assigning points in specific layers:</p>
-
-            <h4>Text</h4>
-            <p>Because a <em>shōdan</em> with text contributes to the development of the narrative, it was assigned a higher ITI than a textless one. Typically, the text of a <em>shōdan</em> is either in prose or poetry. Because poetic texts are seen as raised artistic expression, a <em>shōdan</em>  with poetic text was given a higher ITI. Finally, there are two methods of delivering text, it can either be spoken or chanted. Because spoken <em>shōdan</em> have an introductory function that initiate the narrative rather than develop it, they were assigned lower ITI compared with chanted ones.</p>
-
-            <h4>Music</h4> <p>We looked at the <em>shōdan</em>’s  rhythmic organization and instrumental density.</p>
-
-            <p>Rhythmic Organization: There were three main types of rhythmic organization that we used for our calculations: the spoken <em>shōdan</em> are 'unmetered', while chanted ones are either '<a href="/music/voices/#Non-congruent" target="_blank">non-congruent</a>' or '<a href="/music/voices/#Congruent" target="_blank">congruent</a>.' As mentioned above, we ranked chanted <em>shōdan</em> higher than spoken ones, thus we ranked a 'non-congruent' and 'congruent' <em>shōdan</em> higher than an 'unmetered' one. When it comes to the ranking of 'non-congruent' and 'congruent' <em>shōdan</em>, we considered that the overall rhythmic organization of a play is a constant back-and-forth motion between 'non-congruency' and 'congruency', but ultimately 'non-congruency' gives way to 'congruency.' Thus, 'congruent' <em>shōdan</em> received higher ITI than 'non-congruent' ones. Finally, 'congruent' chants are either set in <a href="/music/voices/#Hiranori" target="_blank"><em>hiranori</em></a>, <a href="/music/voices/#Onori" target="_blank"><em>ōnori</em></a>, or <a href="/music/voices/#Chunori" target="_blank"><em>chūnori</em></a>. <em>Ōnori</em> and <em>chūnori</em> chants have a steady pulse, whereas those set in <em>hiranori</em>  can have a fluctuating one. Thus, mostly found in the final stages of a play, they were given a higher ITI than those set in <em>hiranori</em>.</p>
-
-            <p>Instrumental Density: <em>shōdan</em> with larger instrumentation were ranked higher. A solo nohkan such as a <a href="/catalog-of-shodan/nanoribue/" target="_blank"><em>nanoribue</em></a>, being a textless and unmetered <em>shōdan</em> for a single instrument  was given the lowest rank. Finally, <em>shōdan</em> with two vocal parts (identified with a '2' in the figure below) were ranked higher than those with only one. </p>
-
-            <h4>Dance</h4>  <p>Danced <em>shōdan</em> arrive later and bring an additional layer into the intermedia experience, hence, they were assigned higher ITI than those without dance. There are two types of dance in <em>shōdan</em>: 'dance-to-text' and 'instrumental' or 'pure' dance. The 'instrumental' dance being considered the expressive climax of a play, it was assigned the highest rank. </p>
-
-            <p>The figure below shows the ITI ranking for thirty-four combinations:</p>
-
-            <table id="ITI2" class="content-table" width="100%">
-                  <tr class="content-table__row--header">
-                    <td class="content-table__column" width="6%">ITI</td>
-                    <td class="content-table__column" width="19%">Voice</td>
-                    <td class="content-table__column" width="9%">Drums</td>
-                    <td class="content-table__column" width="19%">Flute</td>
-                    <td class="content-table__column" width="9%">Dance</td>
-                    <td class="content-table__column" width="19%">Hashitomi</td>
-                    <td class="content-table__column" width="19%">Kokaji</td>
-                  </tr>
-                  <tr class="content-table__row">
-                    <td class="content-table__column">(34)</td>
-                    <td class="content-table__column"> – </td>
-                    <td class="content-table__column">Strict</td>
-                    <td class="content-table__column">Congruent</td>
-                    <td class="content-table__column">√</td>
-                    <td class="content-table__column beige"><a href="/hashitomi/jonomai/" target="_blank"><em>Jonomai</em></a></td>
-                    <td class="content-table__column"><a href="/kokaji/maibataraki/" target="_blank"><em>Maibataraki</em></a></td>
-                    </tr>
-                    <tr class="content-table__row">
-                    <td class="content-table__column">(33)</td>
-                    <td class="content-table__column"> – </td>
-                    <td class="content-table__column">Strict</td>
-                    <td class="content-table__column">Non-congruent</td>
-                    <td class="content-table__column">√</td>
-                    <td class="content-table__column"> – </td>
-                    <td class="content-table__column"> – </td>
-                    </tr>
-                    <tr class="content-table__row">
-                    <td class="content-table__column">(32)</td>
-                    <td class="content-table__column">Ō/Chūnori-2</td>
-                    <td class="content-table__column">Strict</td>
-                    <td class="content-table__column">Non-congruent</td>
-                    <td class="content-table__column">√</td>
-                    <td class="content-table__column"><a href="/hashitomi/kiri/" target="_blank"><em>Kiri</em></a></td>
-                    <td class="content-table__column"><a href="/kokaji/kiri/" target="_blank"><em>Kiri</em></a></td>
-                    </tr>
-                    <tr class="content-table__row">
-                    <td class="content-table__column">(31)</td>
-                    <td class="content-table__column">Hiranori-2</td>
-                    <td class="content-table__column">Strict</td>
-                    <td class="content-table__column">Non-congruent</td>
-                    <td class="content-table__column">√</td>
-                    <td class="content-table__column"><a href="/hashitomi/kuse/" target="_blank"><em>Kuse</em></a></td>
-                    <td class="content-table__column"><a href="/kokaji/kuse/" target="_blank"><em>Kuse</em></a></td>
-                    </tr>
-                    <tr class="content-table__row">
-                    <td class="content-table__column">(30)</td>
-                    <td class="content-table__column">Ō/Chūnori</td>
-                    <td class="content-table__column">Strict</td>
-                    <td class="content-table__column">Non-congruent</td>
-                    <td class="content-table__column">√</td>
-                    <td class="content-table__column"> – </td>
-                    <td class="content-table__column"><a href="/kokaji/noriji-2/" target="_blank"><em>Noriji 2</em></a></td>
-                    </tr>
-                    <tr class="content-table__row">
-                    <td class="content-table__column">(29)</td>
-                    <td class="content-table__column">Hiranori</td>
-                    <td class="content-table__column">Strict</td>
-                    <td class="content-table__column">Non-congruent</td>
-                    <td class="content-table__column">√</td>
-                    <td class="content-table__column"> – </td>
-                    <td class="content-table__column"> – </td>
-                    </tr>
-                    <tr class="content-table__row">
-                    <td class="content-table__column">(28)</td>
-                    <td class="content-table__column">Ō/Chūnori-2</td>
-                    <td class="content-table__column">Strict</td>
-                    <td class="content-table__column"> – </td>
-                    <td class="content-table__column">√</td>
-                    <td class="content-table__column"> – </td>
-                    <td class="content-table__column"><a href="/kokaji/noriji-3/" target="_blank"><em>Noriji 3</em></a></td>
-                    </tr>
-                    <tr class="content-table__row">
-                    <td class="content-table__column">(27)</td>
-                    <td class="content-table__column">Hiranori-2</td>
-                    <td class="content-table__column">Strict</td>
-                    <td class="content-table__column"> – </td>
-                    <td class="content-table__column">√</td>
-                    <td class="content-table__column"> – </td>
-                    <td class="content-table__column"> – </td>
-                    </tr>
-                    <tr class="content-table__row">
-                    <td class="content-table__column">(26)</td>
-                    <td class="content-table__column">Ō/Chūnori</td>
-                    <td class="content-table__column">Strict</td>
-                    <td class="content-table__column"> – </td>
-                    <td class="content-table__column">√</td>
-                    <td class="content-table__column"> – </td>
-                    <td class="content-table__column"> – </td>
-                    </tr>
-                    <tr class="content-table__row">
-                    <td class="content-table__column">(25)</td>
-                    <td class="content-table__column">Hiranori</td>
-                    <td class="content-table__column">Strict</td>
-                    <td class="content-table__column"> – </td>
-                    <td class="content-table__column">√</td>
-                    <td class="content-table__column"> – </td>
-                    <td class="content-table__column"><a href="/kokaji/ageuta-3/" target="_blank"><em>Ageuta 3</em></a></td>
-                    </tr>
-                    <tr class="content-table__row">
-                    <td class="content-table__column">(24)</td>
-                    <td class="content-table__column"> – </td>
-                    <td class="content-table__column">Strict</td>
-                    <td class="content-table__column">Congruent</td>
-                    <td class="content-table__column"> – </td>
-                    <td class="content-table__column"> – </td>
-                    <td class="content-table__column"><a href="/kokaji/hayafue/" target="_blank"><em>Hayafue</em></a></td>
-                    </tr>
-                    <tr class="content-table__row">
-                    <td class="content-table__column">(23)</td>
-                    <td class="content-table__column">Ō/Chūnori-2</td>
-                    <td class="content-table__column">Strict</td>
-                    <td class="content-table__column">Non-congruent</td>
-                    <td class="content-table__column"> – </td>
-                    <td class="content-table__column"> – </td>
-                    <td class="content-table__column"> – </td>
-                    </tr>
-                    <tr class="content-table__row">
-                    <td class="content-table__column">(22)</td>
-                    <td class="content-table__column">Hiranori-2</td>
-                    <td class="content-table__column">Strict</td>
-                    <td class="content-table__column">Non-congruent</td>
-                    <td class="content-table__column"> – </td>
-                    <td class="content-table__column"><a href="/hashitomi/rongi/" target="_blank"><em>Rongi</em></a></td>
-                    <td class="content-table__column"><a href="/kokaji/ageuta-1/" target="_blank"><em>Ageuta 1</em></a></td>
-                    </tr>
-                    <tr class="content-table__row">
-                    <td class="content-table__column">(21)</td>
-                    <td class="content-table__column">Ō/Chūnori-2</td>
-                    <td class="content-table__column">Strict</td>
-                    <td class="content-table__column"> – </td>
-                    <td class="content-table__column"> – </td>
-                    <td class="content-table__column"> – </td>
-                    <td class="content-table__column"><a href="/kokaji/noriji-1/" target="_blank"><em>Noriji 1</em></a></td>
-                    </tr>
-                    <tr class="content-table__row">
-                    <td class="content-table__column">(20)</td>
-                    <td class="content-table__column">Ō/Chūnori</td>
-                    <td class="content-table__column">Strict</td>
-                    <td class="content-table__column">Non-congruent</td>
-                    <td class="content-table__column"> – </td>
-                    <td class="content-table__column"> – </td>
-                    <td class="content-table__column"> – </td>
-                    </tr>
-                    <tr class="content-table__row">
-                    <td class="content-table__column">(19)</td>
-                    <td class="content-table__column">Hiranori</td>
-                    <td class="content-table__column">Strict</td>
-                    <td class="content-table__column">Non-congruent</td>
-                    <td class="content-table__column"> – </td><td class="content-table__column"><a href="/hashitomi/ageuta-1/" target="_blank"><em>Ageuta 1</em></a></td>
-                    <td class="content-table__column"><a href="/kokaji/ageuta-2/" target="_blank"><em>Ageuta 2</em></a></td>
-                    </tr>
-                    <tr class="content-table__row">
-                    <td class="content-table__column">(18)</td>
-                    <td class="content-table__column">Ō/Chūnori</td>
-                    <td class="content-table__column">Strict</td>
-                    <td class="content-table__column"> – </td>
-                    <td class="content-table__column"> – </td>
-                    <td class="content-table__column"> – </td>
-                    <td class="content-table__column"> – </td>
-                    </tr>
-                    <tr class="content-table__row">
-                    <td class="content-table__column">(17)</td>
-                    <td class="content-table__column">Hiranori</td>
-                    <td class="content-table__column">Strict</td>
-                    <td class="content-table__column"> – </td>
-                    <td class="content-table__column"> – </td><td class="content-table__column"><a href="/hashitomi/sageuta/" target="_blank"><em>Sageuta</em></a><br><a href="/hashitomi/ageuta-2/" target="_blank"><em>Ageuta 2</em></a></td>
-                    <td class="content-table__column"> – </td>
-                    </tr>
-                    <tr class="content-table__row">
-                    <td class="content-table__column">(16)</td>
-                    <td class="content-table__column">Non-congruent-2</td>
-                    <td class="content-table__column">Strict</td>
-                    <td class="content-table__column">Non-congruent</td>
-                    <td class="content-table__column"> – </td><td class="content-table__column"> – </td>
-                    <td class="content-table__column"> – </td>
-                    </tr>
-                    <tr class="content-table__row">
-                    <td class="content-table__column">(15)</td>
-                    <td class="content-table__column">Non-congruent-2</td>
-                    <td class="content-table__column">Strict</td>
-                    <td class="content-table__column"> – </td>
-                    <td class="content-table__column"> – </td>
-                    <td class="content-table__column"> – </td>
-                    <td class="content-table__column"> – </td>
-                    </tr>
-                    <tr class="content-table__row">
-                    <td class="content-table__column">(14)</td>
-                    <td class="content-table__column">Non-congruent</td>
-                    <td class="content-table__column">Strict</td>
-                    <td class="content-table__column">Non-congruent</td>
-                    <td class="content-table__column"> – </td><td class="content-table__column"><a href="/hashitomi/issei/" target="_blank"><em>Issei</em></a></td>
-                    <td class="content-table__column"><a href="/kokaji/kuri/" target="_blank"><em>Kuri</em></a><br><a href="/kokaji/notto/" target="_blank"><em>Notto</em></a></td>
-                    </tr>
-                    <tr class="content-table__row">
-                    <td class="content-table__column">(13)</td>
-                    <td class="content-table__column">Non-congruent</td>
-                    <td class="content-table__column">Strict</td>
-                    <td class="content-table__column"> – </td>
-                    <td class="content-table__column"> – </td><td class="content-table__column"><a href="/hashitomi/waka/" target="_blank"><em>Waka</em></a></td>
-                    <td class="content-table__column"> – </td>
-                    </tr>
-                    <tr class="content-table__row">
-                    <td class="content-table__column">(12)</td>
-                    <td class="content-table__column"> – </td>
-                    <td class="content-table__column">Strict</td>
-                    <td class="content-table__column">Non-congruent</td>
-                    <td class="content-table__column"> – </td><td class="content-table__column"> – </td>
-                    <td class="content-table__column"><a href="/kokaji/raijo/" target="_blank"><em>Raijo</em></a></td>
-                    </tr>
-                    <tr class="content-table__row">
-                    <td class="content-table__column">(11)</td>
-                    <td class="content-table__column">Non-congruent-2</td>
-                    <td class="content-table__column">Flexible</td>
-                    <td class="content-table__column">Non-congruent</td>
-                    <td class="content-table__column"> – </td>
-                    <td class="content-table__column"> – </td>
-                    <td class="content-table__column"><a href="/kokaji/sashi/" target="_blank"><em>Sashi</em></a></td>
-                    </tr>
-                    <tr class="content-table__row">
-                    <td class="content-table__column">(10)</td>
-                    <td class="content-table__column">Non-congruent</td>
-                    <td class="content-table__column">Flexible</td>
-                    <td class="content-table__column">Non-congruent</td>
-                    <td class="content-table__column"> – </td>
-                    <td class="content-table__column"> – </td>
-                    <td class="content-table__column"> – </td>
-                    </tr>
-                    <tr class="content-table__row">
-                    <td class="content-table__column">(9)</td>
-                    <td class="content-table__column">Non-congruent-2</td>
-                    <td class="content-table__column">Flexible</td>
-                    <td class="content-table__column"> – </td>
-                    <td class="content-table__column"> – </td>
-                    <td class="content-table__column"><a href="/hashitomi/kakaru-1/" target="_blank"><em>Kakaru 1</em><br><a href="/hashitomi/kakaru-2/" target="_blank"><em>Kakaru 2</em></a></td>
-                    <td class="content-table__column"><a href="/kokaji/kakeai-1/" target="_blank"><em>Kakeai 1</em></a><br><a href="/kokaji/kakeai-2/" target="_blank"><em>Kakeai 2</em></a></td>
-                    </tr>
-                    <tr class="content-table__row">
-                    <td class="content-table__column">(8)</td>
-                    <td class="content-table__column">Non-congruent</td>
-                    <td class="content-table__column">Flexible</td>
-                    <td class="content-table__column"> – </td>
-                    <td class="content-table__column"> – </td>
-                    <td class="content-table__column"><a href="/hashitomi/kakaru-3/" target="_blank"><em>Kakaru 3</em></a></td>
-                    <td class="content-table__column"> – </td>
-                    </tr>
-                    <tr class="content-table__row">
-                    <td class="content-table__column">(7)</td>
-                    <td class="content-table__column"> – </td>
-                    <td class="content-table__column">Flexible</td>
-                    <td class="content-table__column">Non-congruent</td>
-                    <td class="content-table__column"> – </td>
-                    <td class="content-table__column"> – </td>
-                    <td class="content-table__column"> – </td>
-                    </tr>
-                    <tr class="content-table__row">
-                    <td class="content-table__column">(6)</td>
-                    <td class="content-table__column">Non-congruent</td>
-                    <td class="content-table__column"> – </td>
-                    <td class="content-table__column"> – </td>
-                    <td class="content-table__column"> – </td>
-                    <td class="content-table__column"><a href="/hashitomi/song/" target="_blank"><em>Song</em></a></td>
-                    <td class="content-table__column"> – </td>
-                    </tr>
-                    <tr class="content-table__row">
-                    <td class="content-table__column">(5)</td>
-                    <td class="content-table__column">Spoken-2</td>
-                    <td class="content-table__column">Flexible</td>
-                    <td class="content-table__column"> – </td>
-                    <td class="content-table__column"> – </td>
-                    <td class="content-table__column"> – </td>
-                    <td class="content-table__column"> – </td>
-                    </tr>
-                    <tr class="content-table__row">
-                    <td class="content-table__column">(4)</td>
-                    <td class="content-table__column">Spoken-2</td>
-                    <td class="content-table__column"> – </td>
-                    <td class="content-table__column"> – </td>
-                    <td class="content-table__column"> – </td>
-                    <td class="content-table__column"><a href="/hashitomi/kakeai/" target="_blank"><em>Kakeai</em></a></td>
-                    <td class="content-table__column"><a href="/kokaji/mondo-1/" target="_blank"><em>Mondō 1</em></a><br><a href="/kokaji/dialogue/" target="_blank"><em>Dialogue</em></a><br><a href="/kokaji/mondo-2/" target="_blank"><em>Mondō 2</em></a></td>
-                    </tr>
-                    <tr class="content-table__row">
-                    <td class="content-table__column">(3)</td>
-                    <td class="content-table__column">Spoken</td>
-                    <td class="content-table__column"> – </td>
-                    <td class="content-table__column"> – </td>
-                    <td class="content-table__column"> – </td>
-                    <td class="content-table__column">  <a href="/hashitomi/nanori/" target="_blank"><em>Nanori</em></a></td>
-                    <td class="content-table__column"><a href="/kokaji/nanori/" target="_blank"><em>Nanori</em></a><br><a href="/kokaji/monologue/" target="_blank"><em>Monologue</em></a></td>
-                    </tr>
-                    <tr class="content-table__row">
-                    <td class="content-table__column">(2)</td>
-                    <td class="content-table__column"> – </td>
-                    <td class="content-table__column">Flexible</td>
-                    <td class="content-table__column"> – </td>
-                    <td class="content-table__column"> – </td>
-                    <td class="content-table__column"><a href="/hashitomi/ashirai/" target="_blank"><em>Ashirai</em></a></td>
-                    <td class="content-table__column"> – </td>
-                    </tr>
-                    <tr class="content-table__row">
-                    <td class="content-table__column">(1)</td>
-                    <td class="content-table__column"> – </td>
-                    <td class="content-table__column"> – </td>
-                    <td class="content-table__column">Non-congruent</td>
-                    <td class="content-table__column"> – </td>
-                    <td class="content-table__column"><a href="/hashitomi/nanoribue/" target="_blank"><em>Nanoribue</em></a></td>
-                    <td class="content-table__column"> – </td>
-                    </tr>
-                    <tr class="content-table__row--header">
-                      <td class="content-table__column">ITI</td>
-                      <td class="content-table__column">Voice</td>
-                      <td class="content-table__column">Drums</td>
-                      <td class="content-table__column">Flute</td>
-                      <td class="content-table__column">Dance</td>
-                      <td class="content-table__column">Hashitomi</td>
-                      <td class="content-table__column">Kokaji</td>
-                    </tr>
-                    </table>
-
-            <p>The ITI method was used to create the '<em>Shōdan</em> Map' that visualizes the intermedia flow of the two featured plays. <a href="/hashitomi/" target="_blank">Hashitomi</a> is composed of 17 <em>shōdan</em> compared to 21 for <a href="/kokaji/" target="_blank">Kokaji</a>. Their respective '<em>Shōdan</em> Map' is shown as blocks under the video. The height of a block represents the <em>shōdan</em>’s  ITI, the width its duration, and the color its section based on <a href="#Intro">Zeami/Yokomichi formal model</a>. Hence, our formal representation is an expansion of that model, by adding and merging with it an intermedia dimension. </p>
-        </div>
-      </section>
-    </div>
-  </div>
-</main>
+{% include second-menu-elements.html %}
+
+<main class="page-content">
+  <div class="text-container">
+
+    <div class="wrapper sidebar-contents">
+      <aside class="sidebar-contents__table">
+        {% include menu-form.html %}
+      </aside>
+      <section class="sidebar-contents__section">
+        <div class="text-container">
+          <h2 id="Intro">Form</h2>
+<h3>Introduction</h3>
+
+
+<p>Zeami (c.1363- c.1443) is credited with having perfected Noh as it exists today. When it came to form, he adapted the Gagaku concept of modulation and movement called <em>Jo-ha-kyū</em>. The tripartite can be summarized as: <em>Jo</em> - slow, <em>Ha</em> - development / acceleration, and <em>Kyū</em> - fast conclusion, suggesting that most efforts should start slowly, speed up, before rapidly ending. Zeami expanded the model from three to five sections by nesting the <em>Jo-ha-kyū</em> concept within the <em>Ha</em>, the tripartite’s longest section. Thus, his adaptation can be summarized as: <em>Jo, Ha-jo, Ha-ha, Ha-kyū, Kyū</em>.</p>
+
+<p>Eventually, the principle of <em>Jo-ha-kyū</em> was applied to various levels of organization. For instance, its basic idea of acceleration has shaped <a href="/catalog-of-shodan/nanori" target="_blank">declamation</a> and <a href="/movement/forward/" target="_blank">movements</a>, among others.</p>
+
+<h3 id="Dan">Dan</h3>
+
+<p>It is the modern scholar, Mario Yokomichi (1916-2012) who created a framework to understand the form of Noh play. Referencing Zeami’s five-section concept, he analyzed the form of typical two acts’ Noh plays attributed to Zeami. Then, he has formulated that each act consists of five sections called <em>dan</em>, that represent common events in the dramatic development of a Noh play.  These are:</p>
+
+<table class="content-table">
+<tr class="content-table__row--header">
+
+<td id="Act1" class="content-table__column">Act I (<em>mae ba</em>)</td>
+
+<td class="content-table__column"></td>
+<td class="content-table__column"></td>
+<td class="content-table__column"></td>
+<td class="content-table__column"></td>
+</tr>
+  <tr class="content-table__row">
+          <td class="content-table__column">Waki Enters</td>
+          <td class="content-table__column">Shite Enters</td>
+          <td class="content-table__column">Dialogue</td>
+          <td class="content-table__column">Shite Performs</td>
+          <td class="content-table__column">Shite Exits</td></tr>
+          <tr class="content-table__row--header">
+
+<td id="Act2" class="content-table__column">Act II (<em>nochi ba</em>)</td>
+
+<td class="content-table__column"></td>
+<td class="content-table__column"></td>
+<td class="content-table__column"></td>
+<td class="content-table__column"></td>
+</tr>
+  <tr class="content-table__row">
+          <td class="content-table__column">Waki Waits</td>
+          <td class="content-table__column">Shite Re-enters</td>
+          <td class="content-table__column">Dialogue</td>
+          <td class="content-table__column">Shite Performs</td>
+          <td class="content-table__column">Shite Exits</td></tr>
+</table>
+
+<p>The above categorizations agree with the traditional divisions shared by actors and musicians. However, we need to acknowledge that the Zeami/Yokomichi’s model is an ideal meant only to help the understanding of an act and facilitate comparisons between plays.  It is not uncommon that some Noh plays lack certain <em>dan</em>. </p>
+
+<h3 id="shodan">Shōdan</h3>
+<p> According to Yokomichi, a <em>dan</em> consists of one or more <em>shōdan</em>. These are conventional units of form that have their own position and syntactical role within a <em>dan</em>. The word <em>shōdan</em>, meaning ‘small dan’, was coined by Mario Yokomichi to further explain the hierarchical character of the form of a Noh play. There are about one hundred different kinds of <em>shōdan</em> that can be categorized into four types: Spoken, Chanted, Entrance and Exit music, and Dance music. Each <em>shōdan</em> is also characterized by a particular combination of poetry or prose, rhythmic setting, melodic shape, and instrumentation. </p>
+
+<p>The same shōdan can be found in various plays. For instance, the majority of Noh plays include a <a href="/catalog-of-shodan/nanori/" target="_blank"><em>nanori</em></a>, a spoken introduction presented by the secondary actor. It can be found <a href="/hashitomi/nanori/" target="_blank">in Hashitomi</a> as well as <a href="/kokaji/nanori/" target="_blank">in Kokaji</a>. Moreover, the same shōdan, such as the main chant <a href="/catalog-of-shodan/ageuta/" target="_blank"><em>ageuta</em></a> for instance, can be used more than once in a play. For example, Hashitomi has two while Kokaji has three. For more information and video examples of <em>shōdan</em> please refer to the <a href="/catalog-of-shodan/" target="_blank">Catalog of Shōdan</a>.</p>
+
+<p> This  <a href="/form-appendix/" target="_blank">appendix</a> provides information on the <em>shōdan</em> commonly associated with the various <em>dan</em>. It is presented solely as a reference-model, since a comparison limited to Hashitomi and Kokaji's form would already show that deviations from that model are not at all uncommon.</p>
+
+<h3 id="modularity">Modularity</h3>
+<p>Thus, the construction of Noh plays, made of sequences of <em>dan</em>, themselves composed of <em>shōdan</em>, is said to be modular. In Noh, the concept of modularity is not exclusively found at the overall formal level, but also within individual media layers such as dance and music. For instance, the nohkan’s melodic patterns are themselves sequenced from shorter modules. The nohkan player varies the patterns' expression to adapt them to given contexts, as illustrated with these examples: <a href="/music/nohkan/nakanotakane/" target="_blank"><em>naka no takane</em></a> and <a href="/music/nohkan/takanemikusari/" target="_blank"><em>takane mi kusari</em></a>. </p>
+
+<p>The patterns played by the percussionists are similarly constructed and controlled. This <a href="/music/otsuzumi-kotsuzumi/#patterns" target="_blank">example</a> shows how the rhythms played by the ōtsuzumi and kotsuzumi performers for an <a href="/catalog-of-shodan/ashirai" target="_blank"><em>Ashirai</em></a>, involve the juxtaposition of <em>mitsuji</em> and <em>tsuzuke</em> patterns. It also illustrates how their expression is altered when the rhythmic setting is strict compared to flexible.</p>
+
+<p>Similarly, dances are constructed using a limited number of movements (<em>kata</em>) that are reused within a dance, a play, and even across plays. Moreover, modularity can be seen in the way that some <em>kata</em> are designed. For instance, the <a href="/movement/back-circlet/" target="_blank">Back Circlet</a> is composed of the sequence of two shorter <em>kata</em>: a Right Step pivot followed by an Open-retreat.  Similarly to music, the unifying impact of modularity is balanced by changing expressive interpretation of patterns performed in a different context. This is shown in a comparison of <a href="/movement/large-zigzag/" target="_blank">two versions</a> of the Large Zigzag: first, as it is performed by a pensive ghost of a young woman in Hashitomi and second, in martial style as performed by the vigorous diety in Kokaji. For more examples of <em>kata</em> please refer to the <a href="/movement/" target="_blank">Catalog of <em>Kata</em></a>.</p>
+
+<h3 id="Both">The Form of Hashitomi and Kokaji</h3>
+
+<p>The Zeami/Yokomichi model should be viewed as a reference rather than an absolute, since few plays follow it exactly. Hashitomi and Kokaji’s form  underlines this point, since both deviate from it somewhat.</p>
+
+<p>In the following two figures, the section's name is linked to the beginning of that section within the play, while the <em>shōdan</em> are linked to their respective intermedia analysis. Not shown in the model but present in both plays is the <em>kyōgen</em> interlude. It is often performed between the two acts but there are no <em>shōdan</em> associated with it. Usually, a <a href="/actors/#Ai" target="_blank">kyōgen</a> actor enters at that moment and engages with the waki. Acting as a local who is well informed about the place’s history, he introduces information that connects the first and second acts.</p>
+
+<h4 id="Hashitomi">Hashitomi</h4>
+
+<p>This figure summarizes Hashitomi's form. It differs from Zeami/Yokomichi model primarily with the missing ‘Shite Performs’ section in the first act, a difference that is not unique to Hashitomi.</p>
+
+            <table class="content-table">
+
+              <tr class="content-table__row--header">
+                <td id="hashitomi-first-act" class="content-table__column">First act <br>(<em>mae ba</em>)</td>
+                <td class="content-table__column"></td>
+                <td class="content-table__column"></td>
+                <td class="content-table__column"></td>
+                <td class="content-table__column"></td>
+              </tr>
+
+              <tr class="content-table__row">
+                <td class="content-table__column"><a href="/hashitomi/#startTime=00:03:38" target="_blank">Waki
+                    Enters</a></td>
+                <td class="content-table__column"><a href="/hashitomi/#startTime=00:08:56" target="_blank">Shite
+                    Enters</a></td>
+                <td class="content-table__column"><a href="/hashitomi/#startTime=00:14:02" target="_blank">Dialogue</a>
+                </td>
+                <td class="content-table__column">
+                  <p>Shite Performs</p>
+                </td>
+                <td class="content-table__column"><a href="/hashitomi/#startTime=00:17:29" target="_blank">Shite
+                    Exits</a></td>
+              </tr>
+
+              <tr class="content-table__row"></tr>
+
+              <tr class="content-table__row">
+                <td class="content-table__column">
+                  <a href="/hashitomi/nanoribue/" target="_blank"><em>Nanoribue</em></a><br>
+                  <a href="/hashitomi/nanori/" target="_blank"><em>Nanori</em></a><br>
+                  <a href="/hashitomi/kakaru-1/" target="_blank"><em>Kakaru 1</em></a>
+                </td>
+
+                <td class="content-table__column">
+                  <a href="/hashitomi/ashirai/" target="_blank"><em>Ashirai</em></a><br>
+                  <a href="/hashitomi/song/" target="_blank"><em>Song</em></a>
+                </td>
+
+                <td class="content-table__column">
+                  <a href="/hashitomi/kakeai/" target="_blank"><em>Kakeai</em></a>
+                </td>
+
+                <td class="content-table__column"> – </td>
+
+                <td class="content-table__column">
+                  <a href="/hashitomi/kakaru-2/" target="_blank"><em>Kakaru 2</em></a><br>
+                  <a href="/hashitomi/ageuta-1/" target="_blank"><em>Ageuta 1</em></a></td>
+
+              </tr>
+            </table>
+
+            <table class="content-table">
+
+              <tr class="content-table__row--header">
+                <td id="hashitomi-second-act" class="content-table__column">Second act <br>(<em>nochi ba</em>)</td>
+                <td class="content-table__column"></td>
+                <td class="content-table__column"></td>
+                <td class="content-table__column"></td>
+                <td class="content-table__column"></td>
+              </tr>
+
+              <tr class="content-table__row">
+                <td class="content-table__column"><a href="/hashitomi/#startTime=00:39:23" target="_blank">Waki
+                    Waits</a></td>
+                <td class="content-table__column"><a href="/hashitomi/#startTime=00:40:56" target="_blank">Shite
+                    Re-enters</a></td>
+                <td class="content-table__column"><a href="/hashitomi/#startTime=00:47:15" target="_blank">Dialogue</a>
+                </td>
+                <td class="content-table__column"><a href="/hashitomi/#startTime=00:51:58" target="_blank">Shite
+                    Performs</td>
+                <td class="content-table__column"><a href="/hashitomi/#startTime=01:17:26" target="_blank">Shite
+                    Exits</a></td>
+              </tr>
+
+              <tr class="content-table__row"></tr>
+
+              <tr class="content-table__row">
+                <td class="content-table__column">
+                  <a href="/hashitomi/kakaru-3/" target="_blank"><em>Kakaru 3</em></a>
+                </td>
+
+                <td class="content-table__column">
+                  <a href="/hashitomi/issei/" target="_blank"><em>Issei</em></a><br>
+                  <a href="/hashitomi/sageuta/" target="_blank"><em>Sageuta</em></a><br>
+                  <a href="/hashitomi/ageuta-2/" target="_blank"><em>Ageuta 2</em></a>
+                </td>
+
+                <td class="content-table__column">
+                  <a href="/hashitomi/rongi/" target="_blank"><em>Rongi</em></a></td>
+
+                <td class="content-table__column">
+                  <a href="/hashitomi/kuse/" target="_blank"><em>Kuse</em></a><br>
+                  <a href="/hashitomi/jonomai/" target="_blank"><em>Jonomai</em></a>
+                </td>
+                <td class="content-table__column">
+                  <a href="/hashitomi/waka/" target="_blank"><em>Waka</em></a><br>
+                  <a href="/hashitomi/kiri/" target="_blank"><em>Kiri</em></a>
+                </td>
+
+              </tr>
+            </table>
+<h4 id="Kokaji">Kokaji</h4>
+
+<p>The figure below summarizes Kokaji's form. It differs from Zeami/Yokomichi with the missing 'Shite Enters' <em>dan</em> in the first act and the ‘Dialogue’ <em>dan</em> in the second. Neither absence is unusual. The actual appearance of the first-act shite happens at the beginning of the 'Dialogue' <em>dan</em>. </p>
+
+            <table class="content-table">
+
+              <tr class="content-table__row--header">
+                <td id="kokaji-first-act" class="content-table__column">First act <br>(<em>mae ba</em>)</td>
+                <td class="content-table__column"></td>
+                <td class="content-table__column"></td>
+                <td class="content-table__column"></td>
+                <td class="content-table__column"></td>
+              </tr>
+
+              <tr class="content-table__row">
+                <td class="content-table__column"><a href="/kokaji/#startTime=00:03:55" target="_blank">Waki Enters</a>
+                </td>
+                <td class="content-table__column">
+                <p>Shite Enters</p>
+                </td>
+
+                <td class="content-table__column"><a href="/kokaji/#startTime=00:12:18" target="_blank">Dialogue</a>
+                </td>
+                <td class="content-table__column"><a href="/kokaji/#startTime=00:16:55" target="_blank">Shite
+                    Performs</a></td>
+                <td class="content-table__column"><a href="/kokaji/#startTime=00:29:07" target="_blank"> Shite Exits</a>
+                </td>
+              </tr>
+
+              <tr class="content-table__row"></tr>
+
+              <tr class="content-table__row">
+                <td class="content-table__column">
+                  <a href="/kokaji/nanori/" target="_blank"><em>Nanori</em></a><br>
+                  <a href="/kokaji/mondo-1/" target="_blank"><em>Mondō 1</em></a><br>
+                  <a href="/kokaji/ageuta-1/" target="_blank"><em>Ageuta 1</em></a><br>
+                  <a href="/kokaji/dialogue/" target="_blank"><em>Dialogue</em></a><br>
+                  <a href="/kokaji/monologue/" target="_blank"><em>Monologue</em></a>
+                </td>
+
+                  <td class="content-table__column"> – </td>
+
+                <td class="content-table__column">
+                  <a href="/kokaji/mondo-2/" target="_blank"><em>Mondō 2</em></a><br>
+                  <a href="/kokaji/ageuta-2/" target="_blank"><em>Ageuta 2</em></a>
+                </td>
+
+
+                <td class="content-table__column">
+                  <a href="/kokaji/kuri/" target="_blank"><em>Kuri</em></a><br>
+                  <a href="/kokaji/sashi/" target="_blank"><em>Sashi</em></a><br>
+                  <a href="/kokaji/kuse/" target="_blank"><em>Kuse</em></a>
+                </td>
+
+                <td class="content-table__column">
+                  <a href="/kokaji/kakeai-1/" target="_blank"><em>Kakeai 1</em></a><br>
+                  <a href="/kokaji/ageuta-3/" target="_blank"><em>Ageuta 3</em></a><br>
+                  <a href="/kokaji/raijo/" target="_blank"><em>Raijo</em></a>
+                </td>
+
+              </tr>
+            </table>
+
+            <table class="content-table">
+
+              <tr class="content-table__row--header">
+                <td id="kokaji-second-act" class="content-table__column">Second act <br>(<em>nochi ba</em>)</td>
+                <td class="content-table__column"></td>
+                <td class="content-table__column"></td>
+                <td class="content-table__column"></td>
+                <td class="content-table__column"></td>
+              </tr>
+
+              <tr class="content-table__row">
+                <td class="content-table__column"><a href="/kokaji/#startTime=00:45:14" target="_blank"> Waki Waits</a>
+                </td>
+                <td class="content-table__column"><a href="/kokaji/#startTime=00:51:07" target="_blank"> Shite
+                    Re-enters</a></td>
+                <td class="content-table__column">
+                  <p>Dialogue</p>
+                </td>
+                <td class="content-table__column"><a href="/kokaji/#startTime=00:52:30" target="_blank"> Shite
+                    Performs</a></td>
+                <td class="content-table__column"><a href="/kokaji/#startTime=00:56:10" target="_blank"> Shite Exits</a>
+                </td>
+              </tr>
+
+              <tr class="content-table__row"></tr>
+
+              <tr class="content-table__row">
+                <td class="content-table__column">
+                  <a href="/kokaji/notto/" target="_blank"><em>Notto</em></a><br>
+                  <a href="/kokaji/noriji-1/" target="_blank"><em>Noriji 1</em></a>
+
+                </td>
+
+                <td class="content-table__column">
+                  <a href="/kokaji/hayafue/" target="_blank"><em>Hayafue</em></a>
+                </td>
+
+                <td class="content-table__column"> – </td>
+
+                <td class="content-table__column">
+                  <a href="/kokaji/noriji-2/" target="_blank"><em>Noriji 2</em></a><br>
+                  <a href="/kokaji/maibataraki/" target="_blank"><em>Maibataraki</em></a><br>
+                  <a href="/kokaji/noriji-3/" target="_blank"><em>Noriji 3</em></a>
+                </td>
+                <td class="content-table__column">
+                  <a href="/kokaji/kakeai-2/" target="_blank"><em>Kakeai 2</em></a><br>
+                  <a href="/kokaji/kiri/" target="_blank"><em>Kiri</em></a>
+                </td>
+
+              </tr>
+            </table>
+
+<h3 id="ITI">Intermedia Texture Index</h3>
+            <p>The focus of our website asked for a general structural representation of Noh that takes into account its intermedia nature. Interestingly, certain qualities in media layers of Noh change predictibly as the play progresses. These layer-based structural tendencies can be observed in particular qualities of text, dance, singing and rhythmic setting of the music, as well as the type of coordination between all of them. We decided to find a system to represent the intermedia tendencies and flow in a graph. We refer to its values as Intermedia Texture Index (ITI). According to our rules, layers exhibiting qualities of a typical earlier stage in the play received fewer and later stage, more 'points'. The 'points' of all graded media layers in a <em>shōdan</em> are then added to give a <em>shōdan</em> its rank. We used this system to assign a rank to all <em>shōdan</em> in the two plays. The resulting sequence of ITI values show how the form of each play is articulated cummulatively by its three main media layers. Obviously, turning rich theatrical experience into numbers is highly reductive but we found the abstraction informative in comparing the flow of intermedia development in different plays.</p>
+            <p>
+            The following explains the rationale of our ranking system for assigning points in specific layers:</p>
+
+            <h4>Text</h4>
+            <p>Because a <em>shōdan</em> with text contributes to the development of the narrative, it was assigned a higher ITI than a textless one. Typically, the text of a <em>shōdan</em> is either in prose or poetry. Because poetic texts are seen as raised artistic expression, a <em>shōdan</em>  with poetic text was given a higher ITI. Finally, there are two methods of delivering text, it can either be spoken or chanted. Because spoken <em>shōdan</em> have an introductory function that initiate the narrative rather than develop it, they were assigned lower ITI compared with chanted ones.</p>
+
+            <h4>Music</h4> <p>We looked at the <em>shōdan</em>’s  rhythmic organization and instrumental density.</p>
+
+            <p>Rhythmic Organization: There were three main types of rhythmic organization that we used for our calculations: the spoken <em>shōdan</em> are 'unmetered', while chanted ones are either '<a href="/music/voices/#Non-congruent" target="_blank">non-congruent</a>' or '<a href="/music/voices/#Congruent" target="_blank">congruent</a>.' As mentioned above, we ranked chanted <em>shōdan</em> higher than spoken ones, thus we ranked a 'non-congruent' and 'congruent' <em>shōdan</em> higher than an 'unmetered' one. When it comes to the ranking of 'non-congruent' and 'congruent' <em>shōdan</em>, we considered that the overall rhythmic organization of a play is a constant back-and-forth motion between 'non-congruency' and 'congruency', but ultimately 'non-congruency' gives way to 'congruency.' Thus, 'congruent' <em>shōdan</em> received higher ITI than 'non-congruent' ones. Finally, 'congruent' chants are either set in <a href="/music/voices/#Hiranori" target="_blank"><em>hiranori</em></a>, <a href="/music/voices/#Onori" target="_blank"><em>ōnori</em></a>, or <a href="/music/voices/#Chunori" target="_blank"><em>chūnori</em></a>. <em>Ōnori</em> and <em>chūnori</em> chants have a steady pulse, whereas those set in <em>hiranori</em>  can have a fluctuating one. Thus, mostly found in the final stages of a play, they were given a higher ITI than those set in <em>hiranori</em>.</p>
+
+            <p>Instrumental Density: <em>shōdan</em> with larger instrumentation were ranked higher. A solo nohkan such as a <a href="/catalog-of-shodan/nanoribue/" target="_blank"><em>nanoribue</em></a>, being a textless and unmetered <em>shōdan</em> for a single instrument  was given the lowest rank. Finally, <em>shōdan</em> with two vocal parts (identified with a '2' in the figure below) were ranked higher than those with only one. </p>
+
+            <h4>Dance</h4>  <p>Danced <em>shōdan</em> arrive later and bring an additional layer into the intermedia experience, hence, they were assigned higher ITI than those without dance. There are two types of dance in <em>shōdan</em>: 'dance-to-text' and 'instrumental' or 'pure' dance. The 'instrumental' dance being considered the expressive climax of a play, it was assigned the highest rank. </p>
+
+            <p>The figure below shows the ITI ranking for thirty-four combinations:</p>
+
+            <table id="ITI2" class="content-table" width="100%">
+                  <tr class="content-table__row--header">
+                    <td class="content-table__column" width="6%">ITI</td>
+                    <td class="content-table__column" width="19%">Voice</td>
+                    <td class="content-table__column" width="9%">Drums</td>
+                    <td class="content-table__column" width="19%">Flute</td>
+                    <td class="content-table__column" width="9%">Dance</td>
+                    <td class="content-table__column" width="19%">Hashitomi</td>
+                    <td class="content-table__column" width="19%">Kokaji</td>
+                  </tr>
+                  <tr class="content-table__row">
+                    <td class="content-table__column">(34)</td>
+                    <td class="content-table__column"> – </td>
+                    <td class="content-table__column">Strict</td>
+                    <td class="content-table__column">Congruent</td>
+                    <td class="content-table__column">√</td>
+                    <td class="content-table__column beige"><a href="/hashitomi/jonomai/" target="_blank"><em>Jonomai</em></a></td>
+                    <td class="content-table__column"><a href="/kokaji/maibataraki/" target="_blank"><em>Maibataraki</em></a></td>
+                    </tr>
+                    <tr class="content-table__row">
+                    <td class="content-table__column">(33)</td>
+                    <td class="content-table__column"> – </td>
+                    <td class="content-table__column">Strict</td>
+                    <td class="content-table__column">Non-congruent</td>
+                    <td class="content-table__column">√</td>
+                    <td class="content-table__column"> – </td>
+                    <td class="content-table__column"> – </td>
+                    </tr>
+                    <tr class="content-table__row">
+                    <td class="content-table__column">(32)</td>
+                    <td class="content-table__column">Ō/Chūnori-2</td>
+                    <td class="content-table__column">Strict</td>
+                    <td class="content-table__column">Non-congruent</td>
+                    <td class="content-table__column">√</td>
+                    <td class="content-table__column"><a href="/hashitomi/kiri/" target="_blank"><em>Kiri</em></a></td>
+                    <td class="content-table__column"><a href="/kokaji/kiri/" target="_blank"><em>Kiri</em></a></td>
+                    </tr>
+                    <tr class="content-table__row">
+                    <td class="content-table__column">(31)</td>
+                    <td class="content-table__column">Hiranori-2</td>
+                    <td class="content-table__column">Strict</td>
+                    <td class="content-table__column">Non-congruent</td>
+                    <td class="content-table__column">√</td>
+                    <td class="content-table__column"><a href="/hashitomi/kuse/" target="_blank"><em>Kuse</em></a></td>
+                    <td class="content-table__column"><a href="/kokaji/kuse/" target="_blank"><em>Kuse</em></a></td>
+                    </tr>
+                    <tr class="content-table__row">
+                    <td class="content-table__column">(30)</td>
+                    <td class="content-table__column">Ō/Chūnori</td>
+                    <td class="content-table__column">Strict</td>
+                    <td class="content-table__column">Non-congruent</td>
+                    <td class="content-table__column">√</td>
+                    <td class="content-table__column"> – </td>
+                    <td class="content-table__column"><a href="/kokaji/noriji-2/" target="_blank"><em>Noriji 2</em></a></td>
+                    </tr>
+                    <tr class="content-table__row">
+                    <td class="content-table__column">(29)</td>
+                    <td class="content-table__column">Hiranori</td>
+                    <td class="content-table__column">Strict</td>
+                    <td class="content-table__column">Non-congruent</td>
+                    <td class="content-table__column">√</td>
+                    <td class="content-table__column"> – </td>
+                    <td class="content-table__column"> – </td>
+                    </tr>
+                    <tr class="content-table__row">
+                    <td class="content-table__column">(28)</td>
+                    <td class="content-table__column">Ō/Chūnori-2</td>
+                    <td class="content-table__column">Strict</td>
+                    <td class="content-table__column"> – </td>
+                    <td class="content-table__column">√</td>
+                    <td class="content-table__column"> – </td>
+                    <td class="content-table__column"><a href="/kokaji/noriji-3/" target="_blank"><em>Noriji 3</em></a></td>
+                    </tr>
+                    <tr class="content-table__row">
+                    <td class="content-table__column">(27)</td>
+                    <td class="content-table__column">Hiranori-2</td>
+                    <td class="content-table__column">Strict</td>
+                    <td class="content-table__column"> – </td>
+                    <td class="content-table__column">√</td>
+                    <td class="content-table__column"> – </td>
+                    <td class="content-table__column"> – </td>
+                    </tr>
+                    <tr class="content-table__row">
+                    <td class="content-table__column">(26)</td>
+                    <td class="content-table__column">Ō/Chūnori</td>
+                    <td class="content-table__column">Strict</td>
+                    <td class="content-table__column"> – </td>
+                    <td class="content-table__column">√</td>
+                    <td class="content-table__column"> – </td>
+                    <td class="content-table__column"> – </td>
+                    </tr>
+                    <tr class="content-table__row">
+                    <td class="content-table__column">(25)</td>
+                    <td class="content-table__column">Hiranori</td>
+                    <td class="content-table__column">Strict</td>
+                    <td class="content-table__column"> – </td>
+                    <td class="content-table__column">√</td>
+                    <td class="content-table__column"> – </td>
+                    <td class="content-table__column"><a href="/kokaji/ageuta-3/" target="_blank"><em>Ageuta 3</em></a></td>
+                    </tr>
+                    <tr class="content-table__row">
+                    <td class="content-table__column">(24)</td>
+                    <td class="content-table__column"> – </td>
+                    <td class="content-table__column">Strict</td>
+                    <td class="content-table__column">Congruent</td>
+                    <td class="content-table__column"> – </td>
+                    <td class="content-table__column"> – </td>
+                    <td class="content-table__column"><a href="/kokaji/hayafue/" target="_blank"><em>Hayafue</em></a></td>
+                    </tr>
+                    <tr class="content-table__row">
+                    <td class="content-table__column">(23)</td>
+                    <td class="content-table__column">Ō/Chūnori-2</td>
+                    <td class="content-table__column">Strict</td>
+                    <td class="content-table__column">Non-congruent</td>
+                    <td class="content-table__column"> – </td>
+                    <td class="content-table__column"> – </td>
+                    <td class="content-table__column"> – </td>
+                    </tr>
+                    <tr class="content-table__row">
+                    <td class="content-table__column">(22)</td>
+                    <td class="content-table__column">Hiranori-2</td>
+                    <td class="content-table__column">Strict</td>
+                    <td class="content-table__column">Non-congruent</td>
+                    <td class="content-table__column"> – </td>
+                    <td class="content-table__column"><a href="/hashitomi/rongi/" target="_blank"><em>Rongi</em></a></td>
+                    <td class="content-table__column"><a href="/kokaji/ageuta-1/" target="_blank"><em>Ageuta 1</em></a></td>
+                    </tr>
+                    <tr class="content-table__row">
+                    <td class="content-table__column">(21)</td>
+                    <td class="content-table__column">Ō/Chūnori-2</td>
+                    <td class="content-table__column">Strict</td>
+                    <td class="content-table__column"> – </td>
+                    <td class="content-table__column"> – </td>
+                    <td class="content-table__column"> – </td>
+                    <td class="content-table__column"><a href="/kokaji/noriji-1/" target="_blank"><em>Noriji 1</em></a></td>
+                    </tr>
+                    <tr class="content-table__row">
+                    <td class="content-table__column">(20)</td>
+                    <td class="content-table__column">Ō/Chūnori</td>
+                    <td class="content-table__column">Strict</td>
+                    <td class="content-table__column">Non-congruent</td>
+                    <td class="content-table__column"> – </td>
+                    <td class="content-table__column"> – </td>
+                    <td class="content-table__column"> – </td>
+                    </tr>
+                    <tr class="content-table__row">
+                    <td class="content-table__column">(19)</td>
+                    <td class="content-table__column">Hiranori</td>
+                    <td class="content-table__column">Strict</td>
+                    <td class="content-table__column">Non-congruent</td>
+                    <td class="content-table__column"> – </td><td class="content-table__column"><a href="/hashitomi/ageuta-1/" target="_blank"><em>Ageuta 1</em></a></td>
+                    <td class="content-table__column"><a href="/kokaji/ageuta-2/" target="_blank"><em>Ageuta 2</em></a></td>
+                    </tr>
+                    <tr class="content-table__row">
+                    <td class="content-table__column">(18)</td>
+                    <td class="content-table__column">Ō/Chūnori</td>
+                    <td class="content-table__column">Strict</td>
+                    <td class="content-table__column"> – </td>
+                    <td class="content-table__column"> – </td>
+                    <td class="content-table__column"> – </td>
+                    <td class="content-table__column"> – </td>
+                    </tr>
+                    <tr class="content-table__row">
+                    <td class="content-table__column">(17)</td>
+                    <td class="content-table__column">Hiranori</td>
+                    <td class="content-table__column">Strict</td>
+                    <td class="content-table__column"> – </td>
+                    <td class="content-table__column"> – </td><td class="content-table__column"><a href="/hashitomi/sageuta/" target="_blank"><em>Sageuta</em></a><br><a href="/hashitomi/ageuta-2/" target="_blank"><em>Ageuta 2</em></a></td>
+                    <td class="content-table__column"> – </td>
+                    </tr>
+                    <tr class="content-table__row">
+                    <td class="content-table__column">(16)</td>
+                    <td class="content-table__column">Non-congruent-2</td>
+                    <td class="content-table__column">Strict</td>
+                    <td class="content-table__column">Non-congruent</td>
+                    <td class="content-table__column"> – </td><td class="content-table__column"> – </td>
+                    <td class="content-table__column"> – </td>
+                    </tr>
+                    <tr class="content-table__row">
+                    <td class="content-table__column">(15)</td>
+                    <td class="content-table__column">Non-congruent-2</td>
+                    <td class="content-table__column">Strict</td>
+                    <td class="content-table__column"> – </td>
+                    <td class="content-table__column"> – </td>
+                    <td class="content-table__column"> – </td>
+                    <td class="content-table__column"> – </td>
+                    </tr>
+                    <tr class="content-table__row">
+                    <td class="content-table__column">(14)</td>
+                    <td class="content-table__column">Non-congruent</td>
+                    <td class="content-table__column">Strict</td>
+                    <td class="content-table__column">Non-congruent</td>
+                    <td class="content-table__column"> – </td><td class="content-table__column"><a href="/hashitomi/issei/" target="_blank"><em>Issei</em></a></td>
+                    <td class="content-table__column"><a href="/kokaji/kuri/" target="_blank"><em>Kuri</em></a><br><a href="/kokaji/notto/" target="_blank"><em>Notto</em></a></td>
+                    </tr>
+                    <tr class="content-table__row">
+                    <td class="content-table__column">(13)</td>
+                    <td class="content-table__column">Non-congruent</td>
+                    <td class="content-table__column">Strict</td>
+                    <td class="content-table__column"> – </td>
+                    <td class="content-table__column"> – </td><td class="content-table__column"><a href="/hashitomi/waka/" target="_blank"><em>Waka</em></a></td>
+                    <td class="content-table__column"> – </td>
+                    </tr>
+                    <tr class="content-table__row">
+                    <td class="content-table__column">(12)</td>
+                    <td class="content-table__column"> – </td>
+                    <td class="content-table__column">Strict</td>
+                    <td class="content-table__column">Non-congruent</td>
+                    <td class="content-table__column"> – </td><td class="content-table__column"> – </td>
+                    <td class="content-table__column"><a href="/kokaji/raijo/" target="_blank"><em>Raijo</em></a></td>
+                    </tr>
+                    <tr class="content-table__row">
+                    <td class="content-table__column">(11)</td>
+                    <td class="content-table__column">Non-congruent-2</td>
+                    <td class="content-table__column">Flexible</td>
+                    <td class="content-table__column">Non-congruent</td>
+                    <td class="content-table__column"> – </td>
+                    <td class="content-table__column"> – </td>
+                    <td class="content-table__column"><a href="/kokaji/sashi/" target="_blank"><em>Sashi</em></a></td>
+                    </tr>
+                    <tr class="content-table__row">
+                    <td class="content-table__column">(10)</td>
+                    <td class="content-table__column">Non-congruent</td>
+                    <td class="content-table__column">Flexible</td>
+                    <td class="content-table__column">Non-congruent</td>
+                    <td class="content-table__column"> – </td>
+                    <td class="content-table__column"> – </td>
+                    <td class="content-table__column"> – </td>
+                    </tr>
+                    <tr class="content-table__row">
+                    <td class="content-table__column">(9)</td>
+                    <td class="content-table__column">Non-congruent-2</td>
+                    <td class="content-table__column">Flexible</td>
+                    <td class="content-table__column"> – </td>
+                    <td class="content-table__column"> – </td>
+                    <td class="content-table__column"><a href="/hashitomi/kakaru-1/" target="_blank"><em>Kakaru 1</em><br><a href="/hashitomi/kakaru-2/" target="_blank"><em>Kakaru 2</em></a></td>
+                    <td class="content-table__column"><a href="/kokaji/kakeai-1/" target="_blank"><em>Kakeai 1</em></a><br><a href="/kokaji/kakeai-2/" target="_blank"><em>Kakeai 2</em></a></td>
+                    </tr>
+                    <tr class="content-table__row">
+                    <td class="content-table__column">(8)</td>
+                    <td class="content-table__column">Non-congruent</td>
+                    <td class="content-table__column">Flexible</td>
+                    <td class="content-table__column"> – </td>
+                    <td class="content-table__column"> – </td>
+                    <td class="content-table__column"><a href="/hashitomi/kakaru-3/" target="_blank"><em>Kakaru 3</em></a></td>
+                    <td class="content-table__column"> – </td>
+                    </tr>
+                    <tr class="content-table__row">
+                    <td class="content-table__column">(7)</td>
+                    <td class="content-table__column"> – </td>
+                    <td class="content-table__column">Flexible</td>
+                    <td class="content-table__column">Non-congruent</td>
+                    <td class="content-table__column"> – </td>
+                    <td class="content-table__column"> – </td>
+                    <td class="content-table__column"> – </td>
+                    </tr>
+                    <tr class="content-table__row">
+                    <td class="content-table__column">(6)</td>
+                    <td class="content-table__column">Non-congruent</td>
+                    <td class="content-table__column"> – </td>
+                    <td class="content-table__column"> – </td>
+                    <td class="content-table__column"> – </td>
+                    <td class="content-table__column"><a href="/hashitomi/song/" target="_blank"><em>Song</em></a></td>
+                    <td class="content-table__column"> – </td>
+                    </tr>
+                    <tr class="content-table__row">
+                    <td class="content-table__column">(5)</td>
+                    <td class="content-table__column">Spoken-2</td>
+                    <td class="content-table__column">Flexible</td>
+                    <td class="content-table__column"> – </td>
+                    <td class="content-table__column"> – </td>
+                    <td class="content-table__column"> – </td>
+                    <td class="content-table__column"> – </td>
+                    </tr>
+                    <tr class="content-table__row">
+                    <td class="content-table__column">(4)</td>
+                    <td class="content-table__column">Spoken-2</td>
+                    <td class="content-table__column"> – </td>
+                    <td class="content-table__column"> – </td>
+                    <td class="content-table__column"> – </td>
+                    <td class="content-table__column"><a href="/hashitomi/kakeai/" target="_blank"><em>Kakeai</em></a></td>
+                    <td class="content-table__column"><a href="/kokaji/mondo-1/" target="_blank"><em>Mondō 1</em></a><br><a href="/kokaji/dialogue/" target="_blank"><em>Dialogue</em></a><br><a href="/kokaji/mondo-2/" target="_blank"><em>Mondō 2</em></a></td>
+                    </tr>
+                    <tr class="content-table__row">
+                    <td class="content-table__column">(3)</td>
+                    <td class="content-table__column">Spoken</td>
+                    <td class="content-table__column"> – </td>
+                    <td class="content-table__column"> – </td>
+                    <td class="content-table__column"> – </td>
+                    <td class="content-table__column">  <a href="/hashitomi/nanori/" target="_blank"><em>Nanori</em></a></td>
+                    <td class="content-table__column"><a href="/kokaji/nanori/" target="_blank"><em>Nanori</em></a><br><a href="/kokaji/monologue/" target="_blank"><em>Monologue</em></a></td>
+                    </tr>
+                    <tr class="content-table__row">
+                    <td class="content-table__column">(2)</td>
+                    <td class="content-table__column"> – </td>
+                    <td class="content-table__column">Flexible</td>
+                    <td class="content-table__column"> – </td>
+                    <td class="content-table__column"> – </td>
+                    <td class="content-table__column"><a href="/hashitomi/ashirai/" target="_blank"><em>Ashirai</em></a></td>
+                    <td class="content-table__column"> – </td>
+                    </tr>
+                    <tr class="content-table__row">
+                    <td class="content-table__column">(1)</td>
+                    <td class="content-table__column"> – </td>
+                    <td class="content-table__column"> – </td>
+                    <td class="content-table__column">Non-congruent</td>
+                    <td class="content-table__column"> – </td>
+                    <td class="content-table__column"><a href="/hashitomi/nanoribue/" target="_blank"><em>Nanoribue</em></a></td>
+                    <td class="content-table__column"> – </td>
+                    </tr>
+                    <tr class="content-table__row--header">
+                      <td class="content-table__column">ITI</td>
+                      <td class="content-table__column">Voice</td>
+                      <td class="content-table__column">Drums</td>
+                      <td class="content-table__column">Flute</td>
+                      <td class="content-table__column">Dance</td>
+                      <td class="content-table__column">Hashitomi</td>
+                      <td class="content-table__column">Kokaji</td>
+                    </tr>
+                    </table>
+
+            <p>The ITI method was used to create the '<em>Shōdan</em> Map' that visualizes the intermedia flow of the two featured plays. <a href="/hashitomi/" target="_blank">Hashitomi</a> is composed of 17 <em>shōdan</em> compared to 21 for <a href="/kokaji/" target="_blank">Kokaji</a>. Their respective '<em>Shōdan</em> Map' is shown as blocks under the video. The height of a block represents the <em>shōdan</em>’s  ITI, the width its duration, and the color its section based on <a href="#Intro">Zeami/Yokomichi formal model</a>. Hence, our formal representation is an expansion of that model, by adding and merging with it an intermedia dimension. </p>
+        </div>
+      </section>
+    </div>
+  </div>
+</main>

--- a/src/form.html
+++ b/src/form.html
@@ -322,7 +322,7 @@ permalink: /form/
 
             <p>The figure below shows the ITI ranking for thirty-four combinations:</p>
 
-            <table id="ITI2" class="content-table" width="100%">
+            <table id="ITI2" class="content-table--iti" width="100%">
                   <tr class="content-table__row--header">
                     <td class="content-table__column" width="6%">ITI</td>
                     <td class="content-table__column" width="19%">Voice</td>

--- a/src/form.html
+++ b/src/form.html
@@ -323,6 +323,7 @@ permalink: /form/
             <p>The figure below shows the ITI ranking for thirty-four combinations:</p>
 
             <table id="ITI2" class="content-table--iti" width="100%">
+              <thead>
                   <tr class="content-table__row--header">
                     <td class="content-table__column" width="6%">ITI</td>
                     <td class="content-table__column" width="19%">Voice</td>
@@ -332,6 +333,7 @@ permalink: /form/
                     <td class="content-table__column" width="19%">Hashitomi</td>
                     <td class="content-table__column" width="19%">Kokaji</td>
                   </tr>
+              </thead>
                   <tr class="content-table__row">
                     <td class="content-table__column">(34)</td>
                     <td class="content-table__column"> – </td>
@@ -631,15 +633,6 @@ permalink: /form/
                     <td class="content-table__column"> – </td>
                     <td class="content-table__column"><a href="/hashitomi/nanoribue/" target="_blank"><em>Nanoribue</em></a></td>
                     <td class="content-table__column"> – </td>
-                    </tr>
-                    <tr class="content-table__row--header">
-                      <td class="content-table__column">ITI</td>
-                      <td class="content-table__column">Voice</td>
-                      <td class="content-table__column">Drums</td>
-                      <td class="content-table__column">Flute</td>
-                      <td class="content-table__column">Dance</td>
-                      <td class="content-table__column">Hashitomi</td>
-                      <td class="content-table__column">Kokaji</td>
                     </tr>
                     </table>
 

--- a/src/form.html
+++ b/src/form.html
@@ -322,6 +322,8 @@ permalink: /form/
 
             <p>The figure below shows the ITI ranking for thirty-four combinations:</p>
 
+            <input type="checkbox" id="content-table--iti__show-all">
+            <label for="content-table--iti__show-all"></label>
             <table id="ITI2" class="content-table--iti" width="100%">
               <thead>
                   <tr class="content-table__row--header">


### PR DESCRIPTION
#### Updates to the Intermedia Texture Index table (`/form/#ITI`).

1. Implements a sticky header / scrolling body, applies a max-height to the body (400px), and enforces column widths.
2. Adds a "show all" / "collapse" button to expand the table to its full glory.

#### Trade-offs / limitations:
* w/r/t (1)
  - to get columns to line up properly, the header has `overflow-y: scroll` applied (this is presumably less awkward on systems with overlaid scrollbars).
  - column widths have to be applied in css (or, I suppose, could be applied to every single row -- classes are applied in a highly-redundant fashion as it stands, so maybe this is preferable?).
  - if these trade-offs are considered intolerable, the presence of the toggle may mean that the fixed header/scrolling body stuff is not even needed?
* w/r/t (2)
  - styling/position of the toggle is basic and provisional -- we may want to do more here.
  - the showing/hiding of additional rows is not easy to animate.  It can be done, if it's considered highly desirable, but will require some off-canvas maths.


Closes #521