### PR TITLE
Touchscreen-friendly header dropdown menus

### DIFF
--- a/src/_includes/header-content.html
+++ b/src/_includes/header-content.html
@@ -12,7 +12,7 @@
   <nav class="header__nav">
     <ul>
       <li class="dropdown-menu{% if page.menu-active == 'about' %} active{% endif %}">
-        <div class="header__main-link dropdown-menu__trigger">About</div>
+        <span class="header__main-link dropdown-menu__trigger">About</span>
         <ul class="dropdown-menu__list">
           <li class="dropdown-menu__title">About</li>
           <li><a href="/guide/">Guide</a></li>
@@ -23,7 +23,7 @@
         </ul>
       </li>
       <li class="dropdown-menu{% if page.menu-active == 'intermedia' %} active{% endif %}">
-        <div class="header__main-link dropdown-menu__trigger">Intermedia</div>
+        <span class="header__main-link dropdown-menu__trigger">Intermedia</span>
         <ul class="dropdown-menu__list">
           <li class="dropdown-menu__title">Intermedia</li>
           <li><a href="/about-intermedia/">À propos</a></li>
@@ -31,7 +31,7 @@
         </ul>
       </li>
       <li class="dropdown-menu{% if page.menu-active == 'plays' %} active{% endif %}">
-        <div class="header__main-link dropdown-menu__trigger">Plays</div>
+        <span class="header__main-link dropdown-menu__trigger">Plays</span>
         <ul class="dropdown-menu__list">
           <li class="dropdown-menu__title">Plays</li>
           <li><a href="/plays/">Why These Plays? </a></li>
@@ -41,7 +41,7 @@
         </ul>
       </li>
       <li class="dropdown-menu{% if page.menu-active == 'elements' %} active{% endif %}">
-        <div class="header__main-link dropdown-menu__trigger">Elements</div>
+        <span class="header__main-link dropdown-menu__trigger">Elements</span>
         <ul class="dropdown-menu__list">
           <li class="dropdown-menu__title">Element</li>
           <li><a href="/elements/">Elements of Noh</a></li>

--- a/src/_includes/header-content.html
+++ b/src/_includes/header-content.html
@@ -11,7 +11,7 @@
 
   <nav class="header__nav">
     <ul>
-      <li class="dropdown-menu{% if page.menu-active == 'about' %} active{% endif %}">
+      <li class="dropdown-menu">
         <span class="header__main-link dropdown-menu__trigger">About</span>
         <ul class="dropdown-menu__list">
           <li class="dropdown-menu__title">About</li>
@@ -22,7 +22,7 @@
 
         </ul>
       </li>
-      <li class="dropdown-menu{% if page.menu-active == 'intermedia' %} active{% endif %}">
+      <li class="dropdown-menu">
         <span class="header__main-link dropdown-menu__trigger">Intermedia</span>
         <ul class="dropdown-menu__list">
           <li class="dropdown-menu__title">Intermedia</li>
@@ -30,7 +30,7 @@
           <li><a href="/about-intermedia/#noh-as-intermedia">Noh as Intermedia</a></li>
         </ul>
       </li>
-      <li class="dropdown-menu{% if page.menu-active == 'plays' %} active{% endif %}">
+      <li class="dropdown-menu">
         <span class="header__main-link dropdown-menu__trigger">Plays</span>
         <ul class="dropdown-menu__list">
           <li class="dropdown-menu__title">Plays</li>
@@ -40,7 +40,7 @@
 
         </ul>
       </li>
-      <li class="dropdown-menu{% if page.menu-active == 'elements' %} active{% endif %}">
+      <li class="dropdown-menu">
         <span class="header__main-link dropdown-menu__trigger">Elements</span>
         <ul class="dropdown-menu__list">
           <li class="dropdown-menu__title">Element</li>

--- a/src/_includes/header-content.html
+++ b/src/_includes/header-content.html
@@ -43,7 +43,7 @@
       <li class="dropdown-menu">
         <span class="header__main-link dropdown-menu__trigger">Elements</span>
         <ul class="dropdown-menu__list">
-          <li class="dropdown-menu__title">Element</li>
+          <li class="dropdown-menu__title">Elements</li>
           <li><a href="/elements/">Elements of Noh</a></li>
           <li><a href="/form/">Form</a></li>
           <li><a href="/actors/">Actors</a></li>

--- a/src/_includes/header-content.html
+++ b/src/_includes/header-content.html
@@ -11,10 +11,10 @@
 
   <nav class="header__nav">
     <ul>
-      <li class="dropdown-menu{% if page.menu-active == 'about' or page.menu-active == 'about' %} active{% endif %}">
-        <a class="header__main-link dropdown-menu__trigger">About</a>
+      <li class="dropdown-menu{% if page.menu-active == 'about' %} active{% endif %}">
+        <div class="header__main-link dropdown-menu__trigger">About</div>
         <ul class="dropdown-menu__list">
-          <li class="dropdown-menu__title"><a href="/">About</a></li>
+          <li class="dropdown-menu__title">About</li>
           <li><a href="/guide/">Guide</a></li>
           <li><a href="/credits/">Credits</a></li>
           <li class="footer__nav-link"><a href="/terms-of-use/">Terms of Use</a></li>
@@ -22,18 +22,18 @@
 
         </ul>
       </li>
-      <li class="dropdown-menu{% if page.menu-active == 'intermedia' or page.menu-active == 'intermedia' %} active{% endif %}">
-        <a class="header__main-link dropdown-menu__trigger">Intermedia</a>
+      <li class="dropdown-menu{% if page.menu-active == 'intermedia' %} active{% endif %}">
+        <div class="header__main-link dropdown-menu__trigger">Intermedia</div>
         <ul class="dropdown-menu__list">
-          <li class="dropdown-menu__title"><a href="/about-intermedia/">Intermedia</a></li>
+          <li class="dropdown-menu__title">Intermedia</li>
           <li><a href="/about-intermedia/">À propos</a></li>
           <li><a href="/about-intermedia/#noh-as-intermedia">Noh as Intermedia</a></li>
         </ul>
       </li>
-      <li class="dropdown-menu{% if page.menu-active == 'plays' or page.menu-active == 'plays' %} active{% endif %}">
-        <a class="header__main-link dropdown-menu__trigger">Plays</a>
+      <li class="dropdown-menu{% if page.menu-active == 'plays' %} active{% endif %}">
+        <div class="header__main-link dropdown-menu__trigger">Plays</div>
         <ul class="dropdown-menu__list">
-          <li class="dropdown-menu__title"><a href="/plays/">Plays</a></li>
+          <li class="dropdown-menu__title">Plays</li>
           <li><a href="/plays/">Why These Plays? </a></li>
           <li><a href="/hashitomi/">Hashitomi </a><a href="/hashitomi/oshirabe/">| Sections</a></li>
           <li><a href="/kokaji/">Kokaji </a><a href="/kokaji/oshirabe/">| Sections</a></li>
@@ -41,9 +41,10 @@
         </ul>
       </li>
       <li class="dropdown-menu{% if page.menu-active == 'elements' %} active{% endif %}">
-        <a class="header__main-link dropdown-menu__trigger">Elements</a>
+        <div class="header__main-link dropdown-menu__trigger">Elements</div>
         <ul class="dropdown-menu__list">
-          <li class="dropdown-menu__title"><a href="/elements/">Elements</a></li>
+          <li class="dropdown-menu__title">Element</li>
+          <li><a href="/elements/">Elements of Noh</a></li>
           <li><a href="/form/">Form</a></li>
           <li><a href="/actors/">Actors</a></li>
           <li><a href="/music/">Music</a></li>

--- a/src/_layouts/default.html
+++ b/src/_layouts/default.html
@@ -3,7 +3,7 @@
 
   {% include head.html %}
 
-  <body class="{{ layout.body-class }}">
+  <body class="{{ layout.body-class }}" onclick>
 
     <header class="header{% if layout.transparent-header %} header--transparent{% endif %}">
       {% include header.html %}

--- a/src/_sass/components/_header.scss
+++ b/src/_sass/components/_header.scss
@@ -154,7 +154,6 @@
     font-weight: $fw-regular;
     cursor: default;
 
-    a {
       align-items: center;
       display: flex;
       padding-right: 1rem;
@@ -175,6 +174,5 @@
         right: 0;
         width: 0;
       }
-    }
   }
 }

--- a/src/_sass/components/_header.scss
+++ b/src/_sass/components/_header.scss
@@ -100,7 +100,7 @@
   padding: 0 0.75rem 0 2rem;
 
   &:hover .dropdown-menu__list {
-      display: block;
+    display: block;
   }
 
 }
@@ -161,18 +161,18 @@
 
       @include text(xs);
 
-      &::after {
-        border-color: $brown transparent transparent transparent;
-        border-style: solid;
-        border-width: 0.1875rem 0.1875rem 0 0.1875rem;
-        content: '';
-        display: block;
-        height: 0;
-        margin-left: 0.25rem;
-        position: absolute;
-        top: 50%;
-        right: 0;
-        width: 0;
-      }
+    &::after {
+      border-color: $brown transparent transparent transparent;
+      border-style: solid;
+      border-width: 0.1875rem 0.1875rem 0 0.1875rem;
+      content: '';
+      display: block;
+      height: 0;
+      margin-left: 0.25rem;
+      position: absolute;
+      top: 50%;
+      right: 0;
+      width: 0;
+    }
   }
 }

--- a/src/_sass/components/_header.scss
+++ b/src/_sass/components/_header.scss
@@ -66,33 +66,6 @@
 
   @include text(xs);
   @include uppercase();
-
-  &:hover {
-    color: $white;
-  }
-}
-
-.dropdown-menu__trigger {
-  align-items: center;
-  display: flex;
-
-  @include text(xs);
-  @include uppercase();
-
-  &::after {
-    border-color: $white80 transparent transparent transparent;
-    border-style: solid;
-    border-width: 0.1875rem 0.1875rem 0 0.1875rem;
-    content: '';
-    display: inline-block;
-    height: 0;
-    margin-left: 0.25rem;
-    position: absolute;
-    right: 0;
-    top: 50%;
-    width: 0;
-  }
-
 }
 
 .dropdown-menu {
@@ -102,7 +75,6 @@
   &:hover .dropdown-menu__list {
     display: block;
   }
-
 }
 
 .dropdown-menu__trigger {
@@ -118,9 +90,12 @@
     border-width: 0.1875rem 0.1875rem 0 0.1875rem;
     content: '';
     display: inline-block;
+    position: absolute;
     height: 0;
     width: 0;
     margin-left: 0.25rem;
+    top: 50%;
+    right: 0;
   }
 }
 


### PR DESCRIPTION
This fixes #549, but should be cleared with the PIs before merging because dropdown-on-touch menu behavior for Android requires that the menu title not be a link, so for the one menu (`Elements`) for which the menu title is not already linked in a sub-item, that sub-item must also be added (`Elements of Noh`). In any case, menu dropdown triggers that are also links are probably best avoided, design-wise.
The fix for the iOS+Safari behavior was both incredibly simple and rather arcane.
A preview is at https://noh-mobile.netlify.com/. It has been tested on Safari, Chrome and Firefox for iOS and Chrome and Firefox for Android.