### PR TITLE
Clip corners of images on front-page cards

### DIFF
--- a/src/_sass/components/website/home-element.scss
+++ b/src/_sass/components/website/home-element.scss
@@ -5,6 +5,7 @@ $card-menu-large-element-size-desktop: 8.75rem;
 .home-element {
   margin-bottom: 10rem;
   text-decoration: none;
+  overflow: hidden;
 
   @include card($color: $beige-dark);
   @include flex-container($justify: center, $align: center);

--- a/src/_sass/components/website/home-play.scss
+++ b/src/_sass/components/website/home-play.scss
@@ -4,6 +4,7 @@ $card-menu-large-element-size-desktop: 8.75rem;
 
 .home-play {
   margin-bottom: 10rem;
+  overflow: hidden;
 
   @include card($color: $beige-light);
   @include flex-container($justify: flex-start, $align: center);


### PR DESCRIPTION
A possibly better alternative might be to add the overflow specification to the mix-in -- I'll let you decide.  Feel free to reject this PR and implement another way if you see fit :)