### PR TITLE
Fixed bug on dropdown menu.

### DIFF
--- a/src/_sass/components/_header.scss
+++ b/src/_sass/components/_header.scss
@@ -80,7 +80,7 @@
 .dropdown-menu {
   margin-left: 2rem;
   position: relative;
-  padding: 0 0.75rem;
+  padding: 1rem 0.75rem;
 
   &:hover {
     .dropdown-menu__list {
@@ -123,7 +123,7 @@
   left: 50%;
   padding: 0.875rem;
   position: absolute;
-  top: 2rem;
+  top: 3rem;
   transform: translateX(-50%);
   white-space: nowrap;
   width: 8rem;
@@ -135,11 +135,21 @@
 
     @include uppercase();
 
+    &:last-child {
+      margin-bottom: 0;
+    }
+
     a {
-      color: $brown;
+      color: rgba($brown, 1);
+      display: block;
       text-decoration: none;
+      transition: color $transition;
 
       @include text(xxs);
+
+      &:hover {
+        color: rgba($brown, 0.7);
+      }
     }
   }
 


### PR DESCRIPTION
This fix affects the blank space between the header link and the dropdown menu. There were some pixels where, when rolling over, the dropdown menu disappears.