### PR TITLE
Sticky jump menu highlight

### DIFF
--- a/src/_layouts/website.html
+++ b/src/_layouts/website.html
@@ -5,6 +5,7 @@ full-width-header: false
 
 {{ content }} {% include footer.html %}
 
+<script type="module" src="/assets/sticky.js"></script>
 <script type="text/javascript" src="/assets/tabs.js"></script>
 <script
   type="text/javascript"

--- a/src/_sass/components/website/anchor-menu.scss
+++ b/src/_sass/components/website/anchor-menu.scss
@@ -5,21 +5,44 @@
   padding: 0.25rem 0.625rem;
 }
 .anchor-menu__element {
-  margin-bottom: 0.25rem;
+  &:not(:last-child) {
+    margin-bottom: 0.25rem;
+  }
 
   a {
     color: $green;
+    position: relative;
+    transition: text-decoration 200ms ease;
+
     @include text(xs);
 
     &:hover {
       text-decoration: none;
     }
-  }
 
-  &.active {
-    > a {
-      font-weight: $fw-bold;
+    &.current {
       text-decoration: none;
+
+      &::before {
+        opacity: 1;
+      }
+    }
+
+    &::before {
+      border-color: transparent transparent transparent $green;
+      border-style: solid;
+      border-width: 0.1875rem 0 0.1875rem 0.1875rem;
+      content: "";
+      display: inline-block;
+      height: 0;
+      margin-left: 0.25rem;
+      opacity: 0;
+      position: absolute;
+      left: -1rem;
+      transition: opacity 200ms ease;
+      top: 50%;
+      transform: translateY(-50%);
+      width: 0;
     }
   }
 }

--- a/src/assets/sticky.js
+++ b/src/assets/sticky.js
@@ -1,0 +1,29 @@
+// Ensure the current section in the sticky jump menu is highlighted.
+
+const sections = Array.from(
+  document.querySelectorAll(".anchor-menu__element a")
+).map(link => document.querySelector(link.hash));
+
+const isInViewport = (elem, { top, height } = elem.getBoundingClientRect()) =>
+  top <= window.innerHeight && top + height >= 0;
+
+const observer = new IntersectionObserver(entries => {
+  entries.forEach((/* entry */) => {
+    sections.some(section => {
+      if (isInViewport(section)) {
+        document
+          .querySelectorAll(`.anchor-menu__element a.current`)
+          .forEach(link => link.classList.remove("current"));
+        document
+          .querySelector(
+            `.anchor-menu__element a[href="#${section.getAttribute("id")}"]`
+          )
+          .classList.add("current");
+        return true;
+      }
+      return false;
+    });
+  });
+});
+
+sections.forEach(section => observer.observe(section));


### PR DESCRIPTION
This PR is intended to replace @inefable's [sticky-menu-highlighted branch](https://github.com/sul-cidr/noh/tree/feature/sticky-menu-highlighted) -- I've taken his styles and re-implemented the behaviour.

Notes:
* This implementation doesn't require any adaptation of the content (HTML/md).
* We've (notionally, at least) tried to set the bar for support at IE11 (no idea where we actually are w/r/t that bar, tbh, but...).  For this reason the other standalone (non-transpiled) scripts on Jekyll-rendered pages have used ES5.  Making this work on IE11 would require a polyfill and some other shennanigans, in addition to writing out all the ES6, so instead it seems appropriate to simply gracefully degrade for IE11 (read: just don't use this highlighting).  The use of `<script type="module">` effectively achieves this (but I would appreciate a test on Safari from someone with a Mac -- thanks!).
* The only wrinkle I'm aware of with this is when scrolling back up -- the indicator moves when the heading comes into the viewport, but the top-bar menus is obscuring it.  Its probably not as simple to solve as it might seem, so I'm proposing we leave it, unless it really offends people eyes :)