### PR TITLE
Only show the corner "info" icon if there's something to show

### DIFF
--- a/src/_includes/video-no-background.html
+++ b/src/_includes/video-no-background.html
@@ -1,4 +1,7 @@
-<!-- {% comment %} Liquid is bad at boolean algebra -- and prettier makes a mess of these assignments. {% endcomment %}
+<!--{% comment %} Liquid is bad at boolean algebra -- and prettier makes a mess of these assignments.
+It's also necessary to reset these variables on every rendering of the template, apparently... {% endcomment %}
+{% assign has_link = false %}{% assign has_title = false %}
+{% assign has_paragraph1 = false %}{% assign has_paragraph2 = false %}{% assign has_paragraph3 = false %}
 {% if include.link and include.link != empty %}{% assign has_link = true %}{% endif %}
 {% if include.title and include.title != empty %}{% assign has_title = true %}{% endif %}
 {% if include.paragraph1 and include.paragraph1 != empty %}{% assign has_paragraph1 = true %}{% endif %}

--- a/src/_includes/video-no-background.html
+++ b/src/_includes/video-no-background.html
@@ -1,19 +1,27 @@
+<!-- {% comment %} Liquid is bad at boolean algebra -- and prettier makes a mess of these assignments. {% endcomment %}
+{% if include.link and include.link != empty %}{% assign has_link = true %}{% endif %}
+{% if include.title and include.title != empty %}{% assign has_title = true %}{% endif %}
+{% if include.paragraph1 and include.paragraph1 != empty %}{% assign has_paragraph1 = true %}{% endif %}
+{% if include.paragraph2 and include.paragraph2 != empty %}{% assign has_paragraph2 = true %}{% endif %}
+{% if include.paragraph3 and include.paragraph3 != empty %}{% assign has_paragraph3 = true %}{% endif %}-->
 <div class="video-website--no-background">
   <div class="video-website__container">
+    {% if has_link or has_title or has_paragraph1 %}
     <a class="video-website__toggle" href="javascript:void(0)">
-      {% if include.link %}<strong>{{ include.link }}</strong>{% endif %}
+      {% if has_link %}<strong>{{ include.link }}</strong>{% endif %}
       <i class="fas fa-info-circle"></i>
     </a>
+    {% endif %}
 
     <div class="video-website__tooltip">
       <div class="video-website__description">
-        {% if include.title %}
+        {% if has_title %}
         <h6>{{ include.title }}</h6>
-        {% endif %} {% if include.paragraph1 %}
+        {% endif %} {% if has_paragraph1 %}
         <p>{{ include.paragraph1 }}</p>
-        {% endif %} {% if include.paragraph2 %}
+        {% endif %} {% if has_paragraph2 %}
         <p>{{ include.paragraph2 }}</p>
-        {% endif %} {% if include.paragraph3 %}
+        {% endif %} {% if has_paragraph3 %}
         <p>{{ include.paragraph3 }}</p>
         {% endif %}
       </div>

--- a/src/_includes/video.html
+++ b/src/_includes/video.html
@@ -1,4 +1,7 @@
-<!-- {% comment %} Liquid is bad at boolean algebra -- and prettier makes a mess of these assignments. {% endcomment %}
+<!--{% comment %} Liquid is bad at boolean algebra -- and prettier makes a mess of these assignments.
+It's also necessary to reset these variables on every rendering of the template, apparently... {% endcomment %}
+{% assign has_link = false %}{% assign has_title = false %}
+{% assign has_paragraph1 = false %}{% assign has_paragraph2 = false %}{% assign has_paragraph3 = false %}
 {% if include.link and include.link != empty %}{% assign has_link = true %}{% endif %}
 {% if include.title and include.title != empty %}{% assign has_title = true %}{% endif %}
 {% if include.paragraph1 and include.paragraph1 != empty %}{% assign has_paragraph1 = true %}{% endif %}

--- a/src/_includes/video.html
+++ b/src/_includes/video.html
@@ -1,17 +1,29 @@
+<!-- {% comment %} Liquid is bad at boolean algebra -- and prettier makes a mess of these assignments. {% endcomment %}
+{% if include.link and include.link != empty %}{% assign has_link = true %}{% endif %}
+{% if include.title and include.title != empty %}{% assign has_title = true %}{% endif %}
+{% if include.paragraph1 and include.paragraph1 != empty %}{% assign has_paragraph1 = true %}{% endif %}
+{% if include.paragraph2 and include.paragraph2 != empty %}{% assign has_paragraph2 = true %}{% endif %}
+{% if include.paragraph3 and include.paragraph3 != empty %}{% assign has_paragraph3 = true %}{% endif %}-->
 <div class="video-website">
   <div class="video-website__container">
-    {% if include.link %}
-    <a class="video-website__toggle" href="">
-      <strong>{{ include.link }}</strong>
+    {% if has_link or has_title or has_paragraph1 %}
+    <a class="video-website__toggle" href="javascript:void(0)">
+      {% if has_link %}<strong>{{ include.link }}</strong>{% endif %}
       <i class="fas fa-info-circle"></i>
     </a>
     {% endif %}
+
     <div class="video-website__tooltip">
       <div class="video-website__description">
+        {% if has_title %}
         <h6>{{ include.title }}</h6>
+        {% endif %} {% if has_paragraph1 %}
         <p>{{ include.paragraph1 }}</p>
+        {% endif %} {% if has_paragraph2 %}
         <p>{{ include.paragraph2 }}</p>
+        {% endif %} {% if has_paragraph3 %}
         <p>{{ include.paragraph3 }}</p>
+        {% endif %}
       </div>
     </div>
     <video id="player" controls="" controlslist="nodownload">


### PR DESCRIPTION
Only show the corner "info" icon if there's something to show and don't print the link text if it's not there.

I think this should cover it.  The problem is we have markup with params provided but empty (e.g. `link=""`, see [src/_includes/otsuzumi-sounds.html](https://github.com/sul-cidr/noh/blob/develop/src/_includes/otsuzumi-sounds.html)), but this should cover all the bases, I think.

Closes #558.