### PR TITLE
Make secondary navbar behave when scrolling and jumping on L0

### DIFF
--- a/src/assets/filters.js
+++ b/src/assets/filters.js
@@ -76,6 +76,7 @@ function attachFilters() {
         });
         // Avoid jump scrolling down to last (often invisible) card, while
         // ensuring the top row of cards isn't obscured by the sticky header
+        jumpInProgress = true;
         document.getElementById("catalog").scrollIntoView();
       },
       false

--- a/src/assets/menu-scroll.js
+++ b/src/assets/menu-scroll.js
@@ -19,17 +19,17 @@ if (secondLevelMenu !== null) {
 
     // Scrolling up
     if (prevScrollPos > currentScrollPos) {
-      if (prevScrollPos - currentScrollPos > 100) {
-        // A jump of this size has been initiated by an anchor or some
-        //  (significant) change to the viewport height -- in this
-        //  case, we want to make sure the menu is stowed away.
-        stickyMenu.classList.remove("visible");
-        prevScrollPos = currentScrollPos;
+      if (Math.abs(prevScrollPos - currentScrollPos < 1)) {
+        // Scrolling to in-page anchor links can produce sub-pixel
+        // "settling" scrolls; ignore these
         return;
       }
       if (currentScrollPos > menuTop) {
         // Slide out floating header if we're not near the page top
-        stickyMenu.classList.add("visible");
+        // and we're not scrolling due to clicking an achor link
+        if (!jumpInProgress) {
+          stickyMenu.classList.add("visible");
+        }
       } else {
         // If we scroll into the page top, let header "dock" normally
         stickyMenu.setAttribute("style", "display: none");
@@ -47,6 +47,7 @@ if (secondLevelMenu !== null) {
       }
     }
     prevScrollPos = currentScrollPos;
+    jumpInProgress = false;
   }
 
   window.addEventListener("scroll", headerShowHide);

--- a/src/assets/tabs.js
+++ b/src/assets/tabs.js
@@ -1,5 +1,7 @@
 var tabClass = "react-tabs__tab";
 
+var jumpInProgress = false;
+
 function attachTabs() {
   /* This function is run after the page loads. It iterates
    * through the "dehydrated" tab containers on the page and
@@ -75,10 +77,16 @@ function activateTab(hashEvent, eltID, scrollToElt) {
     tabLi.setAttribute("aria-selected", "true");
     section.style.display = "block";
 
-    if (hashEvent || scrollToElt) tabLi.scrollIntoView();
+    if (hashEvent || scrollToElt) {
+      jumpInProgress = true;
+      tabLi.scrollIntoView();
+    }
   } else {
     // Be sure to scroll to a non-tab anchors as well, if they're clicked
-    if (scrollToElt) document.getElementById(eltID).scrollIntoView();
+    if (scrollToElt) {
+      jumpInProgress = true;
+      document.getElementById(eltID).scrollIntoView();
+    }
   }
 }
 
@@ -91,9 +99,14 @@ window.addEventListener("hashchange", activateTab, false);
  * focus -- or, if it the link is to a non-tab achor, its target will be
  * scrolled into view.
  */
+const docURL = new URL(document.location.href);
+docURL.hash = "";
+
 document.querySelectorAll('[href*="#"]').forEach(function(link) {
+  const linkURL = new URL(link.href);
+  linkURL.hash = "";
   link.addEventListener("click", function(event) {
-    if (link.href == document.location.href) {
+    if (linkURL.href == docURL.href) {
       event.preventDefault();
       activateTab(null, link.hash.slice(1), true);
     }

--- a/src/assets/tabs.js
+++ b/src/assets/tabs.js
@@ -1,5 +1,7 @@
 var tabClass = "react-tabs__tab";
 
+// Checked in menu-scroll.js to avoid showing the sticky sub-nav
+// menu bar when scrolling up due to clicking an in-page anchor
 var jumpInProgress = false;
 
 function attachTabs() {


### PR DESCRIPTION
This fixes #572 (the secondary "sticky" navbar slides in or out unwelcomely during manual or anchor-driven up-scrolls, respectively, on L0 pages) through the rather brutish expedient of setting a global variable when any in-page anchor link is clicked; the scroll handling code checks this variable before displaying the navbar (or not). This replaces the heuristic of only hiding the navbar on upward scrolls of >100 pixels, which had proved problematic.

This also suppresses unwanted appearances of the navbar on the catalog pages (`/movement/` and `/catalog-of-shodan/`).

Note that the previous code in `tabs.js` for detecting when an in-page anchor link is being clicked didn't work properly.