### PR TITLE
Fix #580

### DIFF
--- a/src/assets/sticky.js
+++ b/src/assets/sticky.js
@@ -1,7 +1,7 @@
 // Ensure the current section in the sticky jump menu is highlighted.
 
 const sections = Array.from(
-  document.querySelectorAll(".anchor-menu__element a")
+  document.querySelectorAll(".anchor-menu__element a[href^='#'")
 ).map(({ hash }) => document.querySelector(hash));
 
 const isInViewport = (elem, { top, height } = elem.getBoundingClientRect()) =>


### PR DESCRIPTION
This works to exclude the links to tabs on `/music/voices/` because they use the full path as well as the fragment hash in the hrefs.  The examples on `/music/voices/` are the only such examples.

FIxes #580.