### PR TITLE
Highlight dans when shodans are highlighted from narratives

### DIFF
--- a/src/_sass/components/videoplayer/_timeline-shodan.scss
+++ b/src/_sass/components/videoplayer/_timeline-shodan.scss
@@ -26,10 +26,7 @@ $shodan-bg-color-active: rgba($red, 0.6);
 @mixin highlight($color, $alpha, $alpha-hover) {
   background-color: rgba($color, $alpha);
 
-  &.dan--highlight {
-    background-color: rgba($color, $alpha-hover);
-  }
-
+  &.dan--highlight,
   &:hover {
     background-color: rgba($color, $alpha-hover);
     .shodan-map__item {
@@ -205,7 +202,7 @@ $shodan-bg-color-active: rgba($red, 0.6);
   }
 
   &.shodan-map__item--highlight {
-    background-color: $shodan-bg-color-hover;
+    background-color: $shodan-bg-color-hover !important;
   }
 }
 

--- a/src/_sass/components/videoplayer/_timeline-shodan.scss
+++ b/src/_sass/components/videoplayer/_timeline-shodan.scss
@@ -23,8 +23,12 @@ $shodan-bg-color-active: rgba($red, 0.6);
   }
 }
 
-@mixin hover($color, $alpha, $alpha-hover) {
+@mixin highlight($color, $alpha, $alpha-hover) {
   background-color: rgba($color, $alpha);
+
+  &.dan--highlight {
+    background-color: rgba($color, $alpha-hover);
+  }
 
   &:hover {
     background-color: rgba($color, $alpha-hover);
@@ -100,24 +104,24 @@ $shodan-bg-color-active: rgba($red, 0.6);
   @include separator();
 
   &.dan-1 {
-    @include hover($dan-1, $alpha, $alpha-hover);
+    @include highlight($dan-1, $alpha, $alpha-hover);
   }
   &.dan-2 {
-    @include hover($dan-2, $alpha, $alpha-hover);
+    @include highlight($dan-2, $alpha, $alpha-hover);
   }
   &.dan-3 {
-    @include hover($dan-3, $alpha, $alpha-hover);
+    @include highlight($dan-3, $alpha, $alpha-hover);
   }
   &.dan-4 {
-    @include hover($dan-4, $alpha, $alpha-hover);
+    @include highlight($dan-4, $alpha, $alpha-hover);
   }
   &.dan-5 {
-    @include hover($dan-5, $alpha, $alpha-hover);
+    @include highlight($dan-5, $alpha, $alpha-hover);
   }
   &.dan-6,
   &.dan-7,
   &.dan-8 {
-    @include hover($white, 0, 0.1);
+    @include highlight($white, 0, 0.1);
 
     .shodan-map__item {
       &[data-is-shodan="false"] {

--- a/webpack/components/TabbedNarrative.jsx
+++ b/webpack/components/TabbedNarrative.jsx
@@ -24,9 +24,10 @@ class TabbedNarrative extends React.Component {
             sectionIndices.forEach(index => {
               container
                 .querySelectorAll(`[data-index="${index}"]`)
-                .forEach(shodanBlock =>
-                  shodanBlock.classList.add("shodan-map__item--highlight")
-                );
+                .forEach(shodanBlock => {
+                  shodanBlock.classList.add("shodan-map__item--highlight");
+                  shodanBlock.parentElement.classList.add("dan--highlight");
+                });
             });
           });
           targetElem.addEventListener("mouseout", (/* event */) => {
@@ -36,9 +37,10 @@ class TabbedNarrative extends React.Component {
             sectionIndices.forEach(index => {
               container
                 .querySelectorAll(`[data-index="${index}"]`)
-                .forEach(shodanBlock =>
-                  shodanBlock.classList.remove("shodan-map__item--highlight")
-                );
+                .forEach(shodanBlock => {
+                  shodanBlock.classList.remove("shodan-map__item--highlight");
+                  shodanBlock.parentElement.classList.remove("dan--highlight");
+                });
             });
           });
         });


### PR DESCRIPTION
This is intended to address #21 .

@inefable I'm a bit puzzled by

> Currently, when rolling over the text on the narratives block, we add the class shodan-map__item--highlight to the individual shodans on the map. This makes it impossible to highlight the dans or the acts.
> We should add classes to acts and dans when rolling over the narratives in order to keep the same behavior to be consistent.

Have I misunderstood something here?  What behaviour are you imagining -- i.e., what would it mean to highlight a dan or an act without highlighting the shōdans?  Let me know if this PR doesn't cover it!