### PR TITLE
Enable analytics

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,6 @@
+src/_layouts/default.html
+src/_layouts/play.html
+src/_layouts/website.html
 src/_includes/filters.html
+src/_includes/google-analytics.html
+src/_includes/head.html

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ script:
   - yarn lint
 
 before_deploy:
-  - yarn build
+  - if [ "$TRAVIS_BRANCH" = "master" ]; then JEKYLL_ENV=production yarn build; else yarn build; fi
 
 env:
   global:

--- a/_config.yml
+++ b/_config.yml
@@ -20,6 +20,8 @@ description: >- # this means to ignore newlines until "baseurl:"
 baseurl: "" # the subpath of your site, e.g. /blog
 url: "" # the base hostname & protocol for your site, e.g. http://example.com
 
+# Google Analytics
+google_analytics: UA-142238250-2
 
 # Build settings
 source: src

--- a/src/_includes/google-analytics.html
+++ b/src/_includes/google-analytics.html
@@ -1,13 +1,5 @@
-<script>
-  window.ga =
-    window.ga ||
-    function() {
-      (ga.q = ga.q || []).push(arguments);
-    };
-  ga.l = +new Date();
-  ga("create", "{{ site.google_analytics }}", "auto");
-  ga("set", "anonymizeIp", true);
-  ga("set", "transport", "beacon");
-  ga("send", "pageview");
-</script>
-<script async src="https://www.google-analytics.com/analytics.js"></script>
+  <script>
+    window.ga = function () { ga.q.push(arguments) };ga.q=[];ga.l=+new Date;
+    ga("create","{{ site.google_analytics }}","auto");ga("set","anonymizeIp",true);ga("set","transport","beacon");ga("send","pageview")
+  </script>
+  <script async src="https://www.google-analytics.com/analytics.js"></script>

--- a/src/_includes/google-analytics.html
+++ b/src/_includes/google-analytics.html
@@ -1,5 +1,5 @@
   <script>
     window.ga = function () { ga.q.push(arguments) };ga.q=[];ga.l=+new Date;
-    ga("create","{{ site.google_analytics }}","auto");ga("set","anonymizeIp",true);ga("set","transport","beacon");ga("send","pageview")
+    ga("create","{{ site.google_analytics }}","auto");ga("set","anonymizeIp",true);ga("set","transport","beacon");ga("send","pageview");
   </script>
   <script async src="https://www.google-analytics.com/analytics.js"></script>

--- a/src/_includes/google-analytics.html
+++ b/src/_includes/google-analytics.html
@@ -6,6 +6,8 @@
     };
   ga.l = +new Date();
   ga("create", "{{ site.google_analytics }}", "auto");
+  ga("set", "anonymizeIp", true);
+  ga("set", "transport", "beacon");
   ga("send", "pageview");
 </script>
 <script async src="https://www.google-analytics.com/analytics.js"></script>

--- a/src/_includes/google-analytics.html
+++ b/src/_includes/google-analytics.html
@@ -1,24 +1,11 @@
 <script>
-  (function(i, s, o, g, r, a, m) {
-    i["GoogleAnalyticsObject"] = r;
-    (i[r] =
-      i[r] ||
-      function() {
-        (i[r].q = i[r].q || []).push(arguments);
-      }),
-      (i[r].l = 1 * new Date());
-    (a = s.createElement(o)), (m = s.getElementsByTagName(o)[0]);
-    a.async = 1;
-    a.src = g;
-    m.parentNode.insertBefore(a, m);
-  })(
-    window,
-    document,
-    "script",
-    "https://www.google-analytics.com/analytics.js",
-    "ga"
-  );
-
+  window.ga =
+    window.ga ||
+    function() {
+      (ga.q = ga.q || []).push(arguments);
+    };
+  ga.l = +new Date();
   ga("create", "{{ site.google_analytics }}", "auto");
   ga("send", "pageview");
 </script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>

--- a/src/_includes/head.html
+++ b/src/_includes/head.html
@@ -1,37 +1,21 @@
 <head>
   <meta charset="utf-8" />
-  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="viewport" content="width=device-width, initial-scale=1">
 
-  <title>
-    {% if page.title %}{{ page.title | escape }}{% else %}{{ site.title | escape
-    }}{% endif %}
-  </title>
-  <meta
-    name="description"
-    content="{{ page.excerpt | default: site.description | strip_html | normalize_whitespace | truncate: 160 | escape }}"
-  />
-  <link
-    rel="canonical"
-    href="{{ page.url | replace:'index.html','' | absolute_url }}"
-  />
+  <title>{% if page.title %}{{ page.title | escape }}{% else %}{{ site.title | escape }}{% endif %}</title>
+  <meta name="description" content="{{ page.excerpt | default: site.description | strip_html | normalize_whitespace | truncate: 160 | escape }}">
+  <link rel="canonical" href="{{ page.url | replace:'index.html','' | absolute_url }}">
 
-  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
-  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
-  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
   <link rel="manifest" href="/site.webmanifest" />
-  <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#6a755e" />
-  <meta name="msapplication-TileColor" content="#6a755e" />
-  <meta name="theme-color" content="#ffffff" />
+  <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#6a755e">
+  <meta name="msapplication-TileColor" content="#6a755e">
+  <meta name="theme-color" content="#ffffff">
 
-  <link
-    rel="stylesheet"
-    href="https://use.fontawesome.com/releases/v5.3.1/css/all.css"
-    integrity="sha384-mzrmE5qonljUremFsqc01SB46JvROS7bZs3IO2EmfFsd15uHvIt+Y8vEf7N7fWAU"
-    crossorigin="anonymous"
-  />
-  <link rel="stylesheet" href="/assets/introjs.min.css" />
-  <link rel="stylesheet" href="{{ "/assets/main.css" | relative_url }}"> {% if
-  jekyll.environment == 'production' and site.google_analytics %} {% include
-  google-analytics.html %} {% endif %}
+  <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.3.1/css/all.css" integrity="sha384-mzrmE5qonljUremFsqc01SB46JvROS7bZs3IO2EmfFsd15uHvIt+Y8vEf7N7fWAU" crossorigin="anonymous">
+  <link rel="stylesheet" href="/assets/introjs.min.css">
+  <link rel="stylesheet" href="{{ "/assets/main.css" | relative_url }}">
+{% if jekyll.environment == 'production' and site.google_analytics %}{% include google-analytics.html %}{% endif %}
 </head>

--- a/src/_layouts/default.html
+++ b/src/_layouts/default.html
@@ -3,9 +3,7 @@
   {% include head.html %}
 
   <body class="{{ layout.body-class }}" onclick>
-    <header
-      class="header{% if layout.transparent-header %} header--transparent{% endif %}"
-    >
+    <header class="header{% if layout.transparent-header %} header--transparent{% endif %}">
       {% include header.html %}
     </header>
 

--- a/src/_layouts/play.html
+++ b/src/_layouts/play.html
@@ -6,9 +6,5 @@ menu-active: "plays"
 <div id="play" class="play-container">
   {{ content }}
 </div>
-<script
-  type="text/javascript"
-  src="/assets/play.bundle.js"
-  charset="utf-8"
-></script>
+<script type="text/javascript" src="/assets/play.bundle.js" charset="utf-8"></script>
 <script type="text/javascript" src="/assets/intro.min.js"></script>

--- a/src/_layouts/website.html
+++ b/src/_layouts/website.html
@@ -7,12 +7,6 @@ full-width-header: false
 
 <script type="module" src="/assets/sticky.js"></script>
 <script type="text/javascript" src="/assets/tabs.js"></script>
-<script
-  type="text/javascript"
-  src="/assets/vanilla-back-to-top.min.js"
-></script>
-<script>
-  addBackToTop();
-</script>
-
+<script type="text/javascript" src="/assets/vanilla-back-to-top.min.js"></script>
+<script>addBackToTop();</script>
 <script type="text/javascript" src="/assets/menu-scroll.js"></script>


### PR DESCRIPTION
Enables Google Analytics on the site, through the Jekyll hooks that were mostly already in place.

**NOTE** that the environment variable `JEKYLL_ENV=production` must be set when building the site to deploy it to production in order for analytics to enabled. This value must **not** be set on any other build; otherwise our local, staging, etc. sites will all send reports to Google as well.