### PR TITLE
Make footnotes work again

### DIFF
--- a/src/assets/tabs.js
+++ b/src/assets/tabs.js
@@ -61,7 +61,6 @@ function activateTab(hashEvent, eltID, scrollToElt) {
     var section = document.querySelector("section#" + eltID);
   } catch {
     section = null;
-    scrollToElt = false;
   }
   if (section) {
     [].forEach.call(section.parentElement.children, function(_section) {


### PR DESCRIPTION
The fixes to the L0 scrolling and anchor-link functionality in #575 broke the ability to follow footnote anchor links from the anchor link in the text to the footnotes section and back (e.g., on `/about-intermedia/`). Actually, the updates broke the ability to jump to any anchor link in the content that didn't match the id of a tab or sticky sidebar section. This should fix it.