### PR TITLE
Added links with icon to level 2 on every shodan page.

### DIFF
--- a/src/_catalog-of-shodan/ageuta.html
+++ b/src/_catalog-of-shodan/ageuta.html
@@ -104,13 +104,21 @@ second-level-menu-active: catalog-shodan
 
     <h3>Examples in the Plays:</h3>
     <p>
-      <a href="/hashitomi/ageuta-1/" target="_blank">Hashitomi - Ageuta 1</a
+      <a href="/hashitomi/ageuta-1/" class="link__level-2" target="_blank"
+        >Hashitomi - Ageuta 1</a
       ><br />
-      <a href="/hashitomi/ageuta-2/" target="_blank">Hashitomi - Ageuta 2</a
+      <a href="/hashitomi/ageuta-2/" class="link__level-2" target="_blank"
+        >Hashitomi - Ageuta 2</a
       ><br /><br />
-      <a href="/kokaji/ageuta-1/" target="_blank">Kokaji - Ageuta 1</a><br />
-      <a href="/kokaji/ageuta-2/" target="_blank">Kokaji - Ageuta 2</a><br />
-      <a href="/kokaji/ageuta-3/" target="_blank">Kokaji - Ageuta 3</a>
+      <a href="/kokaji/ageuta-1/" class="link__level-2" target="_blank"
+        >Kokaji - Ageuta 1</a
+      ><br />
+      <a href="/kokaji/ageuta-2/" class="link__level-2" target="_blank"
+        >Kokaji - Ageuta 2</a
+      ><br />
+      <a href="/kokaji/ageuta-3/" class="link__level-2" target="_blank"
+        >Kokaji - Ageuta 3</a
+      >
     </p>
   </div>
 </main>

--- a/src/_catalog-of-shodan/ai-kyogen.html
+++ b/src/_catalog-of-shodan/ai-kyogen.html
@@ -52,9 +52,12 @@ second-level-menu-active: catalog-shodan
 
     <h3>Examples in the Plays:</h3>
     <p>
-      <a href="/hashitomi/aikyogen/" target="_blank">Hashitomi - Ai-kyōgen</a
+      <a href="/hashitomi/aikyogen/" class="link__level-2" target="_blank"
+        >Hashitomi - Ai-kyōgen</a
       ><br />
-      <a href="/kokaji/aikyogen/" target="_blank">Kokaji - Ai-kyōgen</a>
+      <a href="/kokaji/aikyogen/" class="link__level-2" target="_blank"
+        >Kokaji - Ai-kyōgen</a
+      >
     </p>
   </div>
 </main>

--- a/src/_catalog-of-shodan/ashirai.html
+++ b/src/_catalog-of-shodan/ashirai.html
@@ -56,7 +56,9 @@ second-level-menu-active: catalog-shodan
     %}
     <h3>Example in the Play:</h3>
     <p>
-      <a href="/hashitomi/ashirai/" target="_blank">Hashitomi - Ashirai</a>
+      <a href="/hashitomi/ashirai/" class="link__level-2" target="_blank"
+        >Hashitomi - Ashirai</a
+      >
     </p>
   </div>
 </main>

--- a/src/_catalog-of-shodan/hayafue.md
+++ b/src/_catalog-of-shodan/hayafue.md
@@ -83,7 +83,9 @@ second-level-menu-active: catalog-shodan
     </div>
     <h3>Example in the Play:</h3>
     <p>
-      <a href="/kokaji/hayafue/" target="_blank">Koakji - Hayafue</a>
+      <a href="/kokaji/hayafue/" class="link__level-2" target="_blank"
+        >Koakji - Hayafue</a
+      >
     </p>
   </div>
 </main>

--- a/src/_catalog-of-shodan/issei-chant.html
+++ b/src/_catalog-of-shodan/issei-chant.html
@@ -64,7 +64,9 @@ second-level-menu-active: catalog-shodan
     mode by the shite and jiutai." %}
     <h3>Example in the Play:</h3>
     <p>
-      <a href="/hashitomi/issei/" target="_blank">Hashitomi - Issei</a>
+      <a href="/hashitomi/issei/" class="link__level-2" target="_blank"
+        >Hashitomi - Issei</a
+      >
     </p>
   </div>
 </main>

--- a/src/_catalog-of-shodan/jonomai.html
+++ b/src/_catalog-of-shodan/jonomai.html
@@ -199,7 +199,7 @@ second-level-menu-active: catalog-shodan
     <h3>Example in the Play:</h3>
 
     <p>
-      <a href="/hashitomi/jonomai/" target="_blank"
+      <a href="/hashitomi/jonomai/" class="link__level-2" target="_blank"
         >Hashitomi - <em>Jonomai</em></a
       >
     </p>

--- a/src/_catalog-of-shodan/kakaru.html
+++ b/src/_catalog-of-shodan/kakaru.html
@@ -167,11 +167,15 @@ second-level-menu-active: catalog-shodan
     </div>
     <h3>Examples in the Play:</h3>
     <p>
-      <a href="/hashitomi/kakaru-1/" target="_blank">Hashitomi - Kakaru 1</a
+      <a href="/hashitomi/kakaru-1/" class="link__level-2" target="_blank"
+        >Hashitomi - Kakaru 1</a
       ><br />
-      <a href="/hashitomi/kakaru-2/" target="_blank">Hashitomi - Kakaru 2</a
+      <a href="/hashitomi/kakaru-2/" class="link__level-2" target="_blank"
+        >Hashitomi - Kakaru 2</a
       ><br />
-      <a href="/hashitomi/kakaru-3/" target="_blank">Hashitomi - Kakaru 3</a>
+      <a href="/hashitomi/kakaru-3/" class="link__level-2" target="_blank"
+        >Hashitomi - Kakaru 3</a
+      >
     </p>
   </div>
 </main>

--- a/src/_catalog-of-shodan/kakeai.html
+++ b/src/_catalog-of-shodan/kakeai.html
@@ -1,1 +1,133 @@
----layout: websitename: kakeaifilter-act:filter-type:second-level-menu-active: catalog-shodan---{% include second-menu-elements.html %}<main class="page-content">  <div class="text-container">    <h4><a href="/catalog-of-shodan#catalog">Catalog of Shōdan:</a> Spoken</h4>    <h2>Kakeai</h2>    <div class="introductory-table">      <div class="introductory-table__element">        <div class="introductory-table__term">Voice</div>        <div class="introductory-table__definition">Unmetered</div>      </div>      <div class="introductory-table__element">        <div class="introductory-table__term">Percussion</div>        <div class="introductory-table__definition">Flexible</div>      </div>    </div>    <p>      The <em>Kakeai</em>, whose function is to move the plot forward, is an      unaccompanied dialogue between the shite and the waki. However, it is      sometimes accompanied by the two percussion instruments set in flexible      mode. This is the case when it occurs between two energetic      <em>shōdan</em>, and that the plot is already well established, as it is      the case in Kokaji. Typically, <em>Kakeai</em> starts with      <a href="/text/#Prose" target="_blank">prose</a> delivered in      <a href="/music/voices#Spoken" target="_blank"><em>kotoba</em></a      >, and concludes with unmetered sung verse with      <a href="/text/#Arhythmic" target="_blank">arhythmic</a> text set in      <a href="/music/voices#Sashinori" target="_blank"><em>sashinori</em></a      >. Therefore, text corresponding to the switch of the mode of delivery is      subtly emphasized. When unaccompanied, the singing mode in      <em>Kakeai</em> gives more emphasis to words than the speech mode can.    </p>    <p>      In Noh, the spoken mode tends to be used for conversations between      characters in their immediate present. This changes once a character      starts singing (usually in <em>sashinori</em>). The switch may suggest      that he may now be in a world of his own such as a dream, in a solitary      space, or just sharing a monologue.    </p>    <p>      Between the two plays there are three <em>Kakeai</em>, one in Hashitomi      and two in Kokaji. Hashitomi’s <em>Kakeai</em> is a typical example. It      opens the first act’s ‘Dialogue’ section, and is performed by two actors      without accompaniment. At this point in the play, the shite standing at      the second pine on the bridge, has just completed his entrance chant. The      waki kneeling at      <a href="/staging/stage/#Squares" target="_blank">Square 5</a>, performs a      flower service for Buddha. It is in <em>kotoba</em> that he expresses his      surprise when he notices a white flower he cannot name. The shite replies      is in singing mode rather than in <em>kotoba</em>, and identifies the      flower as <em>iugao</em>. This emphasizes the words and the flower’s name,      an important clue to help reveal that the identity of the character played      by the shite is possibly Lady Yūgao. The waki, staying in singing mode,      asks the woman to identify herself. At this point, she switches back to      <em>kotoba</em> to reaffirm her refusal to divulge her name but hints that      she has come "from the flower’s shadow”.    </p>    <p>      Delivery in      <a href="/music/voices#Spoken" target="_blank"><em>kotoba</em></a> is      recognizable by the declamation's rising tone, identified in the video      with bold syllables. The switching point between the two modes can be      identified by the introduction of the vibrato associated with the singing      mode.    </p>    {% include video-no-background.html    src="https://d3msn78fivoryj.cloudfront.net/Shodan_sl/Hashitomi-Kakeai_Score_sl.mp4"    %}    <p>      Both Kokaji's <em>Kakeai</em> are short, standing between two congruent      <em>shōdan</em>, functioning essentially as bridges. In both cases, the      two percussionists who perform in the adjacent <em>shōdan</em>, continue      to play in the <em>Kakeai</em>, but switch from a strict rhythmic setting      for the adjacent <em>shōdan</em> to flexible for the performance of the      <em>Kakeai</em>.    </p>    <p>      Kokaji’s first <em>Kakeai</em> is performed by two protagonists      accompanied by the two hand-percussion instruments. Positioned between two      congruent <em>shōdan</em> set in      <a href="/music/voices#Hiranori" target="_blank"><em>hiranori</em></a      >: the <em>Kuse</em> and the third <em>Ageuta</em>, it opens the first      act’s ‘Shite exits’ part.    </p>    <p>      Kokaji’s second <em>Kakeai</em> is also performed by two protagonists      accompanied by the two hand-percussion instruments. It opens the second      act’s ‘Shite exits’ part, and is positioned between two congruent      <em>shōdan</em>: the third <em>Noriji</em>, set in      <a href="/music/voices#Onori" target="_blank"><em>ōnori</em></a      >, and the <em>Kiri</em> set mainly in      <a href="/music/voices#Chunori" target="_blank"><em>chūnori</em></a      >.    </p>    <h3>Examples in the Plays:</h3>    <p>      <a href="/hashitomi/kakeai/" target="_blank">Hashitomi - Kakeai</a><br />      <a href="/kokaji/kakeai-1/" target="_blank">Kokaji - Kakeai 1</a><br />      <a href="/kokaji/kakeai-2/" target="_blank">Kokaji - Kakeai 2</a>    </p>  </div></main>
+---
+layout: website
+name: kakeai
+filter-act:
+filter-type:
+second-level-menu-active: catalog-shodan
+---
+
+{% include second-menu-elements.html %}
+
+<main class="page-content">
+  <div class="text-container">
+    <h4><a href="/catalog-of-shodan#catalog">Catalog of Shōdan:</a> Spoken</h4>
+
+    <h2>Kakeai</h2>
+
+    <div class="introductory-table">
+      <div class="introductory-table__element">
+        <div class="introductory-table__term">Voice</div>
+
+        <div class="introductory-table__definition">Unmetered</div>
+      </div>
+
+      <div class="introductory-table__element">
+        <div class="introductory-table__term">Percussion</div>
+
+        <div class="introductory-table__definition">Flexible</div>
+      </div>
+    </div>
+
+    <p>
+      The <em>Kakeai</em>, whose function is to move the plot forward, is an
+      unaccompanied dialogue between the shite and the waki. However, it is
+      sometimes accompanied by the two percussion instruments set in flexible
+      mode. This is the case when it occurs between two energetic
+      <em>shōdan</em>, and that the plot is already well established, as it is
+      the case in Kokaji. Typically, <em>Kakeai</em> starts with
+      <a href="/text/#Prose" target="_blank">prose</a> delivered in
+      <a href="/music/voices#Spoken" target="_blank"><em>kotoba</em></a
+      >, and concludes with unmetered sung verse with
+      <a href="/text/#Arhythmic" target="_blank">arhythmic</a> text set in
+      <a href="/music/voices#Sashinori" target="_blank"><em>sashinori</em></a
+      >. Therefore, text corresponding to the switch of the mode of delivery is
+      subtly emphasized. When unaccompanied, the singing mode in
+      <em>Kakeai</em> gives more emphasis to words than the speech mode can.
+    </p>
+
+    <p>
+      In Noh, the spoken mode tends to be used for conversations between
+      characters in their immediate present. This changes once a character
+      starts singing (usually in <em>sashinori</em>). The switch may suggest
+      that he may now be in a world of his own such as a dream, in a solitary
+      space, or just sharing a monologue.
+    </p>
+
+    <p>
+      Between the two plays there are three <em>Kakeai</em>, one in Hashitomi
+      and two in Kokaji. Hashitomi’s <em>Kakeai</em> is a typical example. It
+      opens the first act’s ‘Dialogue’ section, and is performed by two actors
+      without accompaniment. At this point in the play, the shite standing at
+      the second pine on the bridge, has just completed his entrance chant. The
+      waki kneeling at
+      <a href="/staging/stage/#Squares" target="_blank">Square 5</a>, performs a
+      flower service for Buddha. It is in <em>kotoba</em> that he expresses his
+      surprise when he notices a white flower he cannot name. The shite replies
+      is in singing mode rather than in <em>kotoba</em>, and identifies the
+      flower as <em>iugao</em>. This emphasizes the words and the flower’s name,
+      an important clue to help reveal that the identity of the character played
+      by the shite is possibly Lady Yūgao. The waki, staying in singing mode,
+      asks the woman to identify herself. At this point, she switches back to
+      <em>kotoba</em> to reaffirm her refusal to divulge her name but hints that
+      she has come "from the flower’s shadow”.
+    </p>
+
+    <p>
+      Delivery in
+      <a href="/music/voices#Spoken" target="_blank"><em>kotoba</em></a> is
+      recognizable by the declamation's rising tone, identified in the video
+      with bold syllables. The switching point between the two modes can be
+      identified by the introduction of the vibrato associated with the singing
+      mode.
+    </p>
+
+    {% include video-no-background.html
+    src="https://d3msn78fivoryj.cloudfront.net/Shodan_sl/Hashitomi-Kakeai_Score_sl.mp4"
+    %}
+
+    <p>
+      Both Kokaji's <em>Kakeai</em> are short, standing between two congruent
+      <em>shōdan</em>, functioning essentially as bridges. In both cases, the
+      two percussionists who perform in the adjacent <em>shōdan</em>, continue
+      to play in the <em>Kakeai</em>, but switch from a strict rhythmic setting
+      for the adjacent <em>shōdan</em> to flexible for the performance of the
+      <em>Kakeai</em>.
+    </p>
+
+    <p>
+      Kokaji’s first <em>Kakeai</em> is performed by two protagonists
+      accompanied by the two hand-percussion instruments. Positioned between two
+      congruent <em>shōdan</em> set in
+      <a href="/music/voices#Hiranori" target="_blank"><em>hiranori</em></a
+      >: the <em>Kuse</em> and the third <em>Ageuta</em>, it opens the first
+      act’s ‘Shite exits’ part.
+    </p>
+
+    <p>
+      Kokaji’s second <em>Kakeai</em> is also performed by two protagonists
+      accompanied by the two hand-percussion instruments. It opens the second
+      act’s ‘Shite exits’ part, and is positioned between two congruent
+      <em>shōdan</em>: the third <em>Noriji</em>, set in
+      <a href="/music/voices#Onori" target="_blank"><em>ōnori</em></a
+      >, and the <em>Kiri</em> set mainly in
+      <a href="/music/voices#Chunori" target="_blank"><em>chūnori</em></a
+      >.
+    </p>
+
+    <h3>Examples in the Plays:</h3>
+
+    <p>
+      <a href="/hashitomi/kakeai/" class="link__level-2" target="_blank"
+        >Hashitomi - Kakeai</a
+      ><br />
+
+      <a href="/kokaji/kakeai-1/" class="link__level-2" target="_blank"
+        >Kokaji - Kakeai 1</a
+      ><br />
+
+      <a href="/kokaji/kakeai-2/" class="link__level-2" target="_blank"
+        >Kokaji - Kakeai 2</a
+      >
+    </p>
+  </div>
+</main>

--- a/src/_catalog-of-shodan/kiri.html
+++ b/src/_catalog-of-shodan/kiri.html
@@ -105,8 +105,12 @@ second-level-menu-active: catalog-shodan
     </div>
     <h3>Examples in the Plays:</h3>
     <p>
-      <a href="/hashitomi/kiri/" target="_blank">Hashitomi - Kiri</a><br />
-      <a href="/kokaji/kiri/" target="_blank">Kokaji - Kiri</a>
+      <a href="/hashitomi/kiri/" class="link__level-2" target="_blank"
+        >Hashitomi - Kiri</a
+      ><br />
+      <a href="/kokaji/kiri/" class="link__level-2" target="_blank"
+        >Kokaji - Kiri</a
+      >
     </p>
   </div>
 </main>

--- a/src/_catalog-of-shodan/kuri.html
+++ b/src/_catalog-of-shodan/kuri.html
@@ -96,7 +96,9 @@ second-level-menu-active: catalog-shodan
 
     <h3>Example in the Play:</h3>
     <p>
-      <a href="/kokaji/kuri/" target="_blank">Kokaji - Kuri</a>
+      <a href="/kokaji/kuri/" class="link__level-2" target="_blank"
+        >Kokaji - Kuri</a
+      >
     </p>
   </div>
 </main>

--- a/src/_catalog-of-shodan/kuse.html
+++ b/src/_catalog-of-shodan/kuse.html
@@ -174,8 +174,12 @@ second-level-menu-active: catalog-shodan
     </div>
     <h3>Examples in the Plays:</h3>
     <p>
-      <a href="/hashitomi/kuse/" target="_blank">Hashitomi - Kuse</a><br />
-      <a href="/kokaji/kuse/" target="_blank">Kokaji - Kuse</a>
+      <a href="/hashitomi/kuse/" class="link__level-2" target="_blank"
+        >Hashitomi - Kuse</a
+      ><br />
+      <a href="/kokaji/kuse/" class="link__level-2" target="_blank"
+        >Kokaji - Kuse</a
+      >
     </p>
   </div>
 </main>

--- a/src/_catalog-of-shodan/maibataraki.md
+++ b/src/_catalog-of-shodan/maibataraki.md
@@ -112,7 +112,7 @@ second-level-menu-active: catalog-shodan
     </div>
     <h3>Examples in the Plays:</h3>
     <p>
-      <a href="/kokaji/maibataraki/" target="_blank"
+      <a href="/kokaji/maibataraki/" class="link__level-2" target="_blank"
         >Kokaji - <em>Maibataraki</em></a
       >
     </p>

--- a/src/_catalog-of-shodan/michiyuki.html
+++ b/src/_catalog-of-shodan/michiyuki.html
@@ -32,9 +32,11 @@ second-level-menu-active: catalog-shodan
     </div>
     <p>
       The <em>michiyuki</em> is a kind of
-      <a href="/catalog-of-shodan/ageuta" target="_blank"><em>ageuta</em></a
+      <a href="/catalog-of-shodan/ageuta" class="link__level-2" target="_blank"
+        ><em>ageuta</em></a
       >. Also set in
-      <a href="/music/voices#Hiranori" target="_blank"><em>hiranori</em></a
+      <a href="/music/voices#Hiranori" class="link__level-2" target="_blank"
+        ><em>hiranori</em></a
       >, its overall melodic trajectory compares well with the
       <em>ageuta's</em>. Its text describes a traveler's journey or his emotions
       and usually leads to the entrance music of the shite.

--- a/src/_catalog-of-shodan/mondo.html
+++ b/src/_catalog-of-shodan/mondo.html
@@ -77,8 +77,12 @@ second-level-menu-active: catalog-shodan
     %}
     <h3>Examples in the Play:</h3>
     <p>
-      <a href="/kokaji/mondo-1/" target="_blank">Kokaji - Mondō 1</a><br />
-      <a href="/kokaji/mondo-2/" target="_blank">Kokaji - Mondō 2</a>
+      <a href="/kokaji/mondo-1/" class="link__level-2" target="_blank"
+        >Kokaji - Mondō 1</a
+      ><br />
+      <a href="/kokaji/mondo-2/" class="link__level-2" target="_blank"
+        >Kokaji - Mondō 2</a
+      >
     </p>
   </div>
 </main>

--- a/src/_catalog-of-shodan/nanori.html
+++ b/src/_catalog-of-shodan/nanori.html
@@ -76,8 +76,12 @@ second-level-menu-active: catalog-shodan
     </div>
     <h3>Examples in the Plays:</h3>
     <p>
-      <a href="/hashitomi/nanori/" target="_blank">Hashitomi - Nanori</a><br />
-      <a href="/kokaji/nanori/" target="_blank">Kokaji - Nanori</a>
+      <a href="/hashitomi/nanori/" class="link__level-2" target="_blank"
+        >Hashitomi - Nanori</a
+      ><br />
+      <a href="/kokaji/nanori/" class="link__level-2" target="_blank"
+        >Kokaji - Nanori</a
+      >
     </p>
   </div>
 </main>

--- a/src/_catalog-of-shodan/nanoribue.html
+++ b/src/_catalog-of-shodan/nanoribue.html
@@ -48,7 +48,9 @@ second-level-menu-active: catalog-shodan
     %}
     <h3>Examples in the Play:</h3>
     <p>
-      <a href="/hashitomi/nanoribue/" target="_blank">Hashitomi - Nanoribue</a>
+      <a href="/hashitomi/nanoribue/" class="link__level-2" target="_blank"
+        >Hashitomi - Nanoribue</a
+      >
     </p>
   </div>
 </main>

--- a/src/_catalog-of-shodan/noriji.html
+++ b/src/_catalog-of-shodan/noriji.html
@@ -142,9 +142,15 @@ second-level-menu-active: catalog-shodan
     </div>
     <h3>Examples in the Play:</h3>
     <p>
-      <a href="/kokaji/noriji-1/" target="_blank">Kokaji - Noriji 1</a><br />
-      <a href="/kokaji/noriji-2/" target="_blank">Kokaji - Noriji 2</a><br />
-      <a href="/kokaji/noriji-3/" target="_blank">Kokaji - Noriji 3</a>
+      <a href="/kokaji/noriji-1/" class="link__level-2" target="_blank"
+        >Kokaji - Noriji 1</a
+      ><br />
+      <a href="/kokaji/noriji-2/" class="link__level-2" target="_blank"
+        >Kokaji - Noriji 2</a
+      ><br />
+      <a href="/kokaji/noriji-3/" class="link__level-2" target="_blank"
+        >Kokaji - Noriji 3</a
+      >
     </p>
   </div>
 </main>

--- a/src/_catalog-of-shodan/notto-chant.html
+++ b/src/_catalog-of-shodan/notto-chant.html
@@ -67,7 +67,9 @@ second-level-menu-active: catalog-shodan
     %}
     <h3>Example in the Play:</h3>
     <p>
-      <a href="/kokaji/notto/" target="_blank">Kokaji - Notto</a>
+      <a href="/kokaji/notto/" class="link__level-2" target="_blank"
+        >Kokaji - Notto</a
+      >
     </p>
   </div>
 </main>

--- a/src/_catalog-of-shodan/notto-music.md
+++ b/src/_catalog-of-shodan/notto-music.md
@@ -71,7 +71,9 @@ second-level-menu-active: catalog-shodan
 
     <h3>Example in the Play:</h3>
     <p>
-      <a href="/kokaji/notto/" target="_blank">Kokaji - Notto</a>
+      <a href="/kokaji/notto/" class="link__level-2" target="_blank"
+        >Kokaji - Notto</a
+      >
     </p>
   </div>
 </main>

--- a/src/_catalog-of-shodan/oshirabe.md
+++ b/src/_catalog-of-shodan/oshirabe.md
@@ -101,9 +101,12 @@ second-level-menu-active: catalog-shodan
     </div>
     <h3>Examples in the Plays:</h3>
     <p>
-      <a href="/hashitomi/oshirabe/" target="_blank">Hashitomi - Oshirabe</a
+      <a href="/hashitomi/oshirabe/" class="link__level-2" target="_blank"
+        >Hashitomi - Oshirabe</a
       ><br />
-      <a href="/kokaji/oshirabe/" target="_blank">Kokaji - Oshirabe</a>
+      <a href="/kokaji/oshirabe/" class="link__level-2" target="_blank"
+        >Kokaji - Oshirabe</a
+      >
     </p>
   </div>
 </main>

--- a/src/_catalog-of-shodan/raijo.html
+++ b/src/_catalog-of-shodan/raijo.html
@@ -100,7 +100,9 @@ second-level-menu-active: catalog-shodan
     %}
     <h3>Example in the Play:</h3>
     <p>
-      <a href="/kokaji/raijo/" target="_blank">Kokaji - Raijo</a>
+      <a href="/kokaji/raijo/" class="link__level-2" target="_blank"
+        >Kokaji - Raijo</a
+      >
     </p>
   </div>
 </main>

--- a/src/_catalog-of-shodan/rongi.html
+++ b/src/_catalog-of-shodan/rongi.html
@@ -63,7 +63,9 @@ second-level-menu-active: catalog-shodan
     %}
     <h3>Example in the Play:</h3>
     <p>
-      <a href="/hashitomi/rongi/" target="_blank">Hashitomi - Rongi</a>
+      <a href="/hashitomi/rongi/" class="link__level-2" target="_blank"
+        >Hashitomi - Rongi</a
+      >
     </p>
   </div>
 </main>

--- a/src/_catalog-of-shodan/sageuta.html
+++ b/src/_catalog-of-shodan/sageuta.html
@@ -45,7 +45,9 @@ second-level-menu-active: catalog-shodan
 
     <h3>Example in the Play:</h3>
     <p>
-      <a href="/hashitomi/sageuta/" target="_blank">Hashitomi - Sageuta</a>
+      <a href="/hashitomi/sageuta/" class="link__level-2" target="_blank"
+        >Hashitomi - Sageuta</a
+      >
     </p>
   </div>
 </main>

--- a/src/_catalog-of-shodan/sashi.html
+++ b/src/_catalog-of-shodan/sashi.html
@@ -100,7 +100,9 @@ second-level-menu-active: catalog-shodan
     <h3>Example in the Play:</h3>
 
     <p>
-      <a href="/kokaji/sashi/" target="_blank">Kokaji - <em>Sashi</em></a>
+      <a href="/kokaji/sashi/" class="link__level-2" target="_blank"
+        >Kokaji - <em>Sashi</em></a
+      >
     </p>
   </div>
 </main>

--- a/src/_catalog-of-shodan/waka.html
+++ b/src/_catalog-of-shodan/waka.html
@@ -57,7 +57,9 @@ second-level-menu-active: catalog-shodan
     %}
     <h3>Example in the Play:</h3>
     <p>
-      <a href="/hashitomi/waka/" target="_blank">Hashitomi - Waka</a>
+      <a href="/hashitomi/waka/" class="link__level-2" target="_blank"
+        >Hashitomi - Waka</a
+      >
     </p>
   </div>
 </main>

--- a/src/_sass/commons/_video-links.scss
+++ b/src/_sass/commons/_video-links.scss
@@ -29,3 +29,15 @@ time,
     padding-left: 0.1rem;
   }
 }
+
+.link__level-2 {
+  &::after {
+    color: rgba($red, 1);
+    content: $fa-var-play-circle;
+    display: inline-block;
+    font-family: $font-icon;
+    font-size: 80%;
+    margin-left: 0.25rem;
+    padding-left: 0.1rem;
+  }
+}


### PR DESCRIPTION
On every page under the Catalog of Shodan (Level 0) there are links pointing to examples of these shodans on the plays (Level 2). These links have now an icon indicating the change to level 2.