### PR TITLE
Alternative, more Firefox-friendly Shimai table border styling/hiding

### DIFF
--- a/src/_sass/components/website/shimai-table.scss
+++ b/src/_sass/components/website/shimai-table.scss
@@ -4,6 +4,9 @@ $shimai-border: 0.0625rem solid $beige-dark;
 .shimai-table {
   margin-bottom: 4rem;
   margin-top: 4rem;
+  border-collapse: collapse;
+  border-style: hidden;
+  border-bottom: $shimai-border;
   width: 100%;
   @include wrapper();
 }
@@ -15,10 +18,6 @@ $shimai-border: 0.0625rem solid $beige-dark;
   color: $brown;
   padding: 0.5rem;
   vertical-align: top;
-
-  &:last-child {
-    border-right: none;
-  }
 
   @include text(xs, "text");
 
@@ -39,9 +38,5 @@ $shimai-border: 0.0625rem solid $beige-dark;
 
     @include text(xxs);
     @include uppercase();
-
-    &:last-child {
-      border-right: none;
-    }
   }
 }


### PR DESCRIPTION
As discussed in my [review](https://github.com/sul-cidr/noh/pull/589#pullrequestreview-401236345) for #589, this might be a better way of achieving the desired design of hiding the outermost table borders while retaining the internal ones and the border at the very bottom -- **assuming this is the actual desired styling.** It looks fine for me on Chrome, Safari, and Opera, and on Firefox, only the border of the very bottom right cell of the `/shimai-dances/` table is missing. The small tables on `/IoI/` all appear as they did in the original PR (I think).