### PR TITLE
Style fixes so Font Awesome icons work on Firefox/Chrome/Opera

### DIFF
--- a/src/_includes/header-content.html
+++ b/src/_includes/header-content.html
@@ -39,7 +39,7 @@
         <a
           class="header__main-link header__main-link--with-icon"
           onClick="startIntroPlay()"
-          >Guide <i class="far fa-question-circle"></i
+          >Guide <i class="fas fa-question-circle"></i
         ></a>
       </li>
       {% endif %} {% if page.layout == 'section' %}
@@ -47,7 +47,7 @@
         <a
           class="header__main-link header__main-link--with-icon"
           onClick="startIntroSection()"
-          >Guide <i class="far fa-question-circle"></i
+          >Guide <i class="fas fa-question-circle"></i
         ></a>
       </li>
       {% endif %}

--- a/src/_sass/commons/_mixins.scss
+++ b/src/_sass/commons/_mixins.scss
@@ -138,6 +138,7 @@
     &::before {
       content: $fa-var-th;
       font-family: $font-icon;
+      $font-weight: $fw-icon;
       font-size: $fs-text-sm;
       margin-right: 0.5rem;
     }

--- a/src/_sass/commons/_reset.scss
+++ b/src/_sass/commons/_reset.scss
@@ -87,4 +87,5 @@ video {
 .far,
 .fas {
   font-family: $font-icon;
+  font-weight: $fw-icon;
 }

--- a/src/_sass/commons/_variables-typography.scss
+++ b/src/_sass/commons/_variables-typography.scss
@@ -10,6 +10,7 @@ $font-display: "Source Sans Pro", Helvetica, Arial, sans-serif;
 $font-text: "Source Serif Pro", Georgia, serif;
 $font-icon: "Font Awesome 5 Free";
 
+$fw-icon: 900;
 $fw-light: 300;
 $fw-regular: 400;
 $fw-semibold: 600;

--- a/src/_sass/commons/_video-links.scss
+++ b/src/_sass/commons/_video-links.scss
@@ -12,6 +12,7 @@ time,
     content: $fa-var-forward;
     display: inline-block;
     font-family: $font-icon;
+    font-weight: $fw-icon;
     font-size: 70%;
     margin-left: 0.125rem;
     padding-left: 0.1rem;
@@ -24,6 +25,7 @@ time,
     content: $fa-var-external-link;
     display: inline-block;
     font-family: $font-icon;
+    font-weight: $fw-icon;
     font-size: 70%;
     margin-left: 0.125rem;
     padding-left: 0.1rem;
@@ -36,6 +38,7 @@ time,
     content: $fa-var-play-circle;
     display: inline-block;
     font-family: $font-icon;
+    font-weight: $fw-icon;
     font-size: 80%;
     margin-left: 0.25rem;
     padding-left: 0.1rem;

--- a/src/_sass/components/_checkbox.scss
+++ b/src/_sass/components/_checkbox.scss
@@ -50,8 +50,8 @@
       align-items: center;
       display: flex;
       font-family: $font-icon;
+      font-weight: $fw-icon;
       font-style: normal;
-      font-weight: normal;
       justify-content: center;
       top: 0.0625rem;
     }

--- a/src/_sass/components/videoplayer/_introjs.scss
+++ b/src/_sass/components/videoplayer/_introjs.scss
@@ -12,6 +12,7 @@
     color: rgba($red, 0.8);
     display: inline-block;
     font-family: $font-icon;
+    font-weight: $fw-icon;
     font-size: 70%;
   }
 }

--- a/src/_sass/components/videoplayer/_narrative.scss
+++ b/src/_sass/components/videoplayer/_narrative.scss
@@ -18,6 +18,7 @@
       content: $fa-var-caret-right;
       display: flex;
       font-family: $font-icon;
+      font-weight: $fw-icon;
       font-size: $fs-display-xxs;
       height: 1rem;
       justify-content: center;

--- a/src/_sass/components/website/mini-cards.scss
+++ b/src/_sass/components/website/mini-cards.scss
@@ -41,6 +41,7 @@
   .audio-player::after,
   .audio-playing::after {
     font-family: $font-icon;
+    font-weight: $fw-icon;
     font-size: 1.5rem;
     color: $green64;
     position: absolute;

--- a/src/_sass/layouts/_video-player.scss
+++ b/src/_sass/layouts/_video-player.scss
@@ -76,6 +76,7 @@
       margin-left: 0.125rem;
       position: relative;
       font-family: $font-icon;
+      font-weight: $fw-icon;
       font-size: 80%;
       top: 0;
 

--- a/webpack/__tests__/__snapshots__/play.spec.jsx.snap
+++ b/webpack/__tests__/__snapshots__/play.spec.jsx.snap
@@ -3875,7 +3875,7 @@ exports[`<Play> renders as expected 1`] = `
                         Intro.
                       </span>
                       <div
-                        className="dan dan- dan-7"
+                        className="dan dan-no-tooltip dan-7"
                         key="dan-block-7"
                         style={
                           Object {
@@ -3991,6 +3991,7 @@ exports[`<Play> renders as expected 1`] = `
                       </span>
                       <div
                         className="dan dan-waki-enters dan-1"
+                        data-tooltip="Waki Enters"
                         key="dan-block-1"
                         style={
                           Object {
@@ -4227,6 +4228,7 @@ exports[`<Play> renders as expected 1`] = `
                       </div>
                       <div
                         className="dan dan-dialogue dan-3"
+                        data-tooltip="Dialogue"
                         key="dan-block-3"
                         style={
                           Object {
@@ -4328,6 +4330,7 @@ exports[`<Play> renders as expected 1`] = `
                       </div>
                       <div
                         className="dan dan-shite-performs dan-4"
+                        data-tooltip="Shite Performs"
                         key="dan-block-4"
                         style={
                           Object {
@@ -4474,6 +4477,7 @@ exports[`<Play> renders as expected 1`] = `
                       </div>
                       <div
                         className="dan dan-shite-exits dan-5"
+                        data-tooltip="Shite Exits"
                         key="dan-block-5"
                         style={
                           Object {
@@ -4633,7 +4637,7 @@ exports[`<Play> renders as expected 1`] = `
                         Interlude
                       </span>
                       <div
-                        className="dan dan- dan-6"
+                        className="dan dan-no-tooltip dan-6"
                         key="dan-block-6"
                         style={
                           Object {
@@ -4749,6 +4753,7 @@ exports[`<Play> renders as expected 1`] = `
                       </span>
                       <div
                         className="dan dan-waki-waits dan-1"
+                        data-tooltip="Waki Waits"
                         key="dan-block-1"
                         style={
                           Object {
@@ -4850,6 +4855,7 @@ exports[`<Play> renders as expected 1`] = `
                       </div>
                       <div
                         className="dan dan-shite-re-enters dan-2"
+                        data-tooltip="Shite Re-enters"
                         key="dan-block-2"
                         style={
                           Object {
@@ -4906,6 +4912,7 @@ exports[`<Play> renders as expected 1`] = `
                       </div>
                       <div
                         className="dan dan-shite-performs dan-4"
+                        data-tooltip="Shite Performs"
                         key="dan-block-4"
                         style={
                           Object {
@@ -5052,6 +5059,7 @@ exports[`<Play> renders as expected 1`] = `
                       </div>
                       <div
                         className="dan dan-shite-exits dan-5"
+                        data-tooltip="Shite Exits"
                         key="dan-block-5"
                         style={
                           Object {
@@ -5166,7 +5174,7 @@ exports[`<Play> renders as expected 1`] = `
                         Exit
                       </span>
                       <div
-                        className="dan dan- dan-8"
+                        className="dan dan-no-tooltip dan-8"
                         key="dan-block-8"
                         style={
                           Object {

--- a/webpack/__tests__/__snapshots__/shodantimeline.spec.jsx.snap
+++ b/webpack/__tests__/__snapshots__/shodantimeline.spec.jsx.snap
@@ -18,7 +18,7 @@ exports[`<ShodanTimeline> renders as expected 1`] = `
       Intro.
     </span>
     <div
-      className="dan dan- dan-7"
+      className="dan dan-no-tooltip dan-7"
       key="dan-block-7"
       style={
         Object {
@@ -70,6 +70,7 @@ exports[`<ShodanTimeline> renders as expected 1`] = `
     </span>
     <div
       className="dan dan-waki-enters dan-1"
+      data-tooltip="Waki Enters"
       key="dan-block-1"
       style={
         Object {
@@ -146,6 +147,7 @@ exports[`<ShodanTimeline> renders as expected 1`] = `
     </div>
     <div
       className="dan dan-dialogue dan-3"
+      data-tooltip="Dialogue"
       key="dan-block-3"
       style={
         Object {
@@ -183,6 +185,7 @@ exports[`<ShodanTimeline> renders as expected 1`] = `
     </div>
     <div
       className="dan dan-shite-performs dan-4"
+      data-tooltip="Shite Performs"
       key="dan-block-4"
       style={
         Object {
@@ -233,6 +236,7 @@ exports[`<ShodanTimeline> renders as expected 1`] = `
     </div>
     <div
       className="dan dan-shite-exits dan-5"
+      data-tooltip="Shite Exits"
       key="dan-block-5"
       style={
         Object {
@@ -296,7 +300,7 @@ exports[`<ShodanTimeline> renders as expected 1`] = `
       Interlude
     </span>
     <div
-      className="dan dan- dan-6"
+      className="dan dan-no-tooltip dan-6"
       key="dan-block-6"
       style={
         Object {
@@ -348,6 +352,7 @@ exports[`<ShodanTimeline> renders as expected 1`] = `
     </span>
     <div
       className="dan dan-waki-waits dan-1"
+      data-tooltip="Waki Waits"
       key="dan-block-1"
       style={
         Object {
@@ -385,6 +390,7 @@ exports[`<ShodanTimeline> renders as expected 1`] = `
     </div>
     <div
       className="dan dan-shite-re-enters dan-2"
+      data-tooltip="Shite Re-enters"
       key="dan-block-2"
       style={
         Object {
@@ -409,6 +415,7 @@ exports[`<ShodanTimeline> renders as expected 1`] = `
     </div>
     <div
       className="dan dan-shite-performs dan-4"
+      data-tooltip="Shite Performs"
       key="dan-block-4"
       style={
         Object {
@@ -459,6 +466,7 @@ exports[`<ShodanTimeline> renders as expected 1`] = `
     </div>
     <div
       className="dan dan-shite-exits dan-5"
+      data-tooltip="Shite Exits"
       key="dan-block-5"
       style={
         Object {
@@ -509,7 +517,7 @@ exports[`<ShodanTimeline> renders as expected 1`] = `
       Exit
     </span>
     <div
-      className="dan dan- dan-8"
+      className="dan dan-no-tooltip dan-8"
       key="dan-block-8"
       style={
         Object {

--- a/webpack/components/ShodanTimelineBlock.jsx
+++ b/webpack/components/ShodanTimelineBlock.jsx
@@ -29,7 +29,6 @@ class ShodanTimelineBlock extends Component {
       window.location.pathname === this.props.url
         ? "shodan-map__item--active"
         : "";
-    //const tooltipText = `${this.props.name}`;
     return (
       <div
         className={`shodan-map__item ${pointer} ${active} shodan-map__item--${this.props.shodanIndex}`}


### PR DESCRIPTION
The best way I've found to ensure that the Font Awesome 5 Free icons appear properly on non-Safari browsers is to set `font-weight: 900` for all custom styles applied to the icons. We should be aware, though, that *some* icons in this set do support weights other than 900, and for example a lower weight can change the icon from solid to outline, as is the case with the `fa-question-circle` icon that now appears next to the `Guide` menu option. But in most cases, using the "normal" weight of 400 results in a broken icon.