### PR TITLE
Remove padding from above filters menu

### DIFF
--- a/src/_sass/components/_filters.scss
+++ b/src/_sass/components/_filters.scss
@@ -16,7 +16,6 @@
   flex-shrink: 0;
   padding-right: 1rem;
   position: sticky;
-  top: 50px;
   overflow-y: auto;
   max-height: calc(
     100vh - 50px - 10px


### PR DESCRIPTION
With Firefox, Chrome and Opera (test on Mac OS only), the checkbox menu on the sidebar of the catalog pages (`/movement/`, `/catalog-of-shodan/`) tends to jump annoyingly when the top checkbox items (e.g., `Still Position (2)` on `/movement/`) are selected and deselected. This seems to be due to some interaction with the scroll behavior of the sidebar and the main content column as cards are displayed and hidden. Removing the 50-pixel margin above the filters controls makes this behavior go away. It's not obvious why that margin needs to be there at all; unless someone knows a reason, I think it would be better to get rid of it.