### PR TITLE
Update Google Analytics to use dynamic tagging

### DIFF
--- a/src/_includes/google-analytics.html
+++ b/src/_includes/google-analytics.html
@@ -1,5 +1,7 @@
+  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-142238250-2"></script>
   <script>
-    window.ga = function () { ga.q.push(arguments) };ga.q=[];ga.l=+new Date;
-    ga("create","{{ site.google_analytics }}","auto");ga("set","anonymizeIp",true);ga("set","transport","beacon");ga("send","pageview");
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'UA-142238250-2');
   </script>
-  <script async src="https://www.google-analytics.com/analytics.js"></script>


### PR DESCRIPTION
This uses the recommended new snippet and has been tested to work with the GA dashboard after building the site locally with `JEKYLL_ENV=production`. The change seems to make no material difference to the dashboard reports, but at least we shouldn't get any more emails about it.