### PR TITLE
Migrate Google Analytics tracking to GA4

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -21,7 +21,7 @@ baseurl: "" # the subpath of your site, e.g. /blog
 url: "" # the base hostname & protocol for your site, e.g. http://example.com
 
 # Google Analytics
-google_analytics: UA-142238250-2
+google_analytics: G-0N46F423RG
 
 # Build settings
 source: src

--- a/src/_includes/google-analytics.html
+++ b/src/_includes/google-analytics.html
@@ -1,7 +1,7 @@
-  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-142238250-2"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'UA-142238250-2');
-  </script>
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-0N46F423RG"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-0N46F423RG');
+</script>


### PR DESCRIPTION
As with the DASH front-end, this was tested locally with the updated tags, and the site properly reported the visit to the Google mother ship. I'll skip the screenshot this time, since it looks very much like the one from the DASH PR.