### PR TITLE
Darken video window (reduce its opacity) immediately during seeking

### DIFF
--- a/src/_sass/layouts/_video-player.scss
+++ b/src/_sass/layouts/_video-player.scss
@@ -185,6 +185,10 @@
     position: absolute;
     width: 100%;
   }
+
+  .video-seeking {
+    opacity: 0.25;
+  }
 }
 
 .timeline {

--- a/webpack/__tests__/__snapshots__/mastervideo.spec.jsx.snap
+++ b/webpack/__tests__/__snapshots__/mastervideo.spec.jsx.snap
@@ -13,6 +13,7 @@ exports[`<MasterVideo> renders as expected 1`] = `
       controls={true}
       controlsList="nodownload"
       id="player"
+      onSeeked={[Function]}
       onSeeking={[Function]}
       onTimeUpdate={[Function]}
     >

--- a/webpack/__tests__/__snapshots__/play.spec.jsx.snap
+++ b/webpack/__tests__/__snapshots__/play.spec.jsx.snap
@@ -2152,6 +2152,7 @@ exports[`<Play> renders as expected 1`] = `
                     controls={true}
                     controlsList="nodownload"
                     id="player"
+                    onSeeked={[Function]}
                     onSeeking={[Function]}
                     onTimeUpdate={[Function]}
                   >

--- a/webpack/__tests__/mastervideo.spec.jsx
+++ b/webpack/__tests__/mastervideo.spec.jsx
@@ -86,6 +86,16 @@ describe("<MasterVideo>", () => {
       expect(store.getActions()[0]).toEqual(action);
     });
 
+    it("sets the video player opacity while seeking", () => {
+      wrapper.find("video").simulate("seeking");
+      expect(wrapper.find("video").hasClass("video-seeking"));
+    });
+
+    it("resets the video player opacity after seeking", () => {
+      wrapper.find("video").simulate("seeked");
+      expect(!wrapper.find("video").hasClass("video-seeking"));
+    });
+
     it("triggers the SET_CURRENT_TIME action with the right payload when timeupdate", () => {
       const action = {
         type: "SET_CURRENT_TIME",

--- a/webpack/components/MasterVideo.jsx
+++ b/webpack/components/MasterVideo.jsx
@@ -50,7 +50,11 @@ class MasterVideo extends Component {
           controls
           controlsList="nodownload"
           onTimeUpdate={event => this.props.updateCurrentTime(event)}
-          onSeeking={event => this.props.updateCurrentTime(event)}
+          onSeeking={event => {
+            this.video.classList.add("video-seeking");
+            this.props.updateCurrentTime(event);
+          }}
+          onSeeked={() => this.video.classList.remove("video-seeking")}
         >
           <source src={this.props.videoUrl} type="video/mp4" />
           {tracks}


### PR DESCRIPTION
Addresses #638.

If the video player element's loading spinner appeared immediately on seek, this wouldn't be needed, but as the issue notes, that often doesn't occur during common usage situations on many browsers. I think it's preferable to give the user some immediate feedback that the seek is occurring via this rather rudimentary method, even if it may sometimes overlap with the eventual appearance of the loading spinner.